### PR TITLE
Add Python 3 support

### DIFF
--- a/cmake_format/__main__.py
+++ b/cmake_format/__main__.py
@@ -209,7 +209,7 @@ def main():
     config_dict.update(vars(args))
     cfg = configuration.Configuration(**config_dict)
     if args.in_place:
-      outfile = tempfile.NamedTemporaryFile(delete=False)
+      outfile = tempfile.NamedTemporaryFile(delete=False, mode='w')
     else:
       if args.outfile_path == '-':
         outfile = sys.stdout

--- a/cmake_format/__main__.py
+++ b/cmake_format/__main__.py
@@ -181,7 +181,7 @@ def main():
       title='Formatter Configuration',
       description='Override configfile options')
 
-  for key, value in configuration.Configuration().as_dict().iteritems():
+  for key, value in configuration.Configuration().as_dict().items():
     flag = '--{}'.format(key.replace('_', '-'))
     if isinstance(value, (dict, list)):
       continue

--- a/cmake_format/common.py
+++ b/cmake_format/common.py
@@ -26,7 +26,7 @@ class EnumObject(object):
 
   @classmethod
   def assign_names(cls):
-    for key, value in vars(cls).iteritems():
+    for key, value in vars(cls).items():
       if isinstance(value, cls):
         value.name_ = key
 

--- a/cmake_format/configuration.py
+++ b/cmake_format/configuration.py
@@ -72,7 +72,7 @@ class Configuration(ConfigObject):
 
     self.fn_spec = commands.get_fn_spec()
     if additional_commands is not None:
-      for command_name, spec in additional_commands.iteritems():
+      for command_name, spec in additional_commands.items():
         commands.decl_command(self.fn_spec, command_name, **spec)
 
   def clone(self):

--- a/cmake_format/lexer.py
+++ b/cmake_format/lexer.py
@@ -30,7 +30,7 @@ def token_type_to_str(query):
   """
   Return the string name of a token type enum value.
   """
-  for name, value in globals().iteritems():
+  for name, value in globals().items():
     if name[0].upper() == name[0] and value == query:
       return name
   return None


### PR DESCRIPTION
This resolves the following problems under Python 3 while maintaining Python 2.7 support.

```
Traceback (most recent call last):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/myint/tmp/cmake_format/cmake_format/__main__.py", line 245, in <module>
    sys.exit(main())
  File "/Users/myint/tmp/cmake_format/cmake_format/__main__.py", line 184, in main
    for key, value in configuration.Configuration().as_dict().iteritems():
AttributeError: 'dict' object has no attribute 'iteritems'
```

```
Traceback (most recent call last):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/myint/tmp/cmake_format/cmake_format/__main__.py", line 245, in <module>
    sys.exit(main())
  File "/Users/myint/tmp/cmake_format/cmake_format/__main__.py", line 223, in main
    process_file(cfg, infile, outfile)
  File "/Users/myint/tmp/cmake_format/cmake_format/__main__.py", line 38, in process_file
    pretty_printer.print_node(fst)
  File "/Users/myint/tmp/cmake_format/cmake_format/formatter.py", line 594, in print_node
    self.print_block(node)
  File "/Users/myint/tmp/cmake_format/cmake_format/formatter.py", line 453, in print_block
    self.print_node(child)
  File "/Users/myint/tmp/cmake_format/cmake_format/formatter.py", line 600, in print_node
    self.print_statement(node)
  File "/Users/myint/tmp/cmake_format/cmake_format/formatter.py", line 573, in print_statement
    self.outfile.write(self.get_indent())
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/tempfile.py", line 483, in func_wrapper
    return func(*args, **kwargs)
TypeError: a bytes-like object is required, not 'str'
```