### PR TITLE
Distinguish whitespace from newlines

### DIFF
--- a/cmake_format/lexer.py
+++ b/cmake_format/lexer.py
@@ -88,7 +88,7 @@ def tokenize(contents):
       (r"(?<![^\s\(])\${[a-zA-z_][a-zA-Z0-9_]*}(?![^\s\)])",
        lambda s, t: (DEREF, t)),
       (r"\n", lambda s, t: (NEWLINE, t)),
-      (r"\s+", lambda s, t: (WHITESPACE, t)),
+      (r"[ \t]+", lambda s, t: (WHITESPACE, t)),
       (r"#\s*cmake-format: off[^\n]*", lambda s, t: (FORMAT_OFF, t)),
       (r"#\s*cmake-format: on[^\n]*", lambda s, t: (FORMAT_ON, t)),
       # bracket comment

--- a/cmake_format/lexer_tests.py
+++ b/cmake_format/lexer_tests.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import unittest
 
-from cmake_format import __main__
 from cmake_format import lexer
 
 
@@ -34,6 +33,9 @@ class TestSpecificLexings(unittest.TestCase):
       #    whitespace is removed.]==]
       """, [lexer.WHITESPACE, lexer.BRACKET_COMMENT, lexer.NEWLINE,
             lexer.WHITESPACE])
+
+  def test_trailiing_whitespace(self):
+    self.assert_tok_types(" \n", [lexer.WHITESPACE, lexer.NEWLINE])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes the newline corruption in #21.