### PR TITLE
Break before args

### DIFF
--- a/cmake_format/configuration.py
+++ b/cmake_format/configuration.py
@@ -84,6 +84,7 @@ class Configuration(ConfigObject):
                enum_char=None,
                line_ending=None,
                command_case=None,
+               break_before_args=False,
                additional_commands=None, **_):
 
     self.line_width = line_width
@@ -110,6 +111,8 @@ class Configuration(ConfigObject):
     self.line_ending = get_default(line_ending, u"unix")
     self.command_case = get_default(command_case, u"lower")
     assert self.command_case in (u"lower", u"upper", u"unchanged")
+
+    self.break_before_args = break_before_args
 
     self.additional_commands = get_default(additional_commands, {
         'foo': {
@@ -171,6 +174,8 @@ VARDOCS = {
     "What style line endings to use in the output.",
     "command_case":
     "Format command names consistently as 'lower' or 'upper' case",
+    "break_before_args":
+    "Always add a linebreak between a keyword and its arguments",
     "additional_commands":
     "Specify structure for custom cmake functions"
 }

--- a/cmake_format/doc/README.rst
+++ b/cmake_format/doc/README.rst
@@ -98,6 +98,9 @@ pleasant way.
     # "unchanged"
     command_case = u'lower'
 
+    # Always add a linebreak between a keyword and its arguments
+    break_before_args = False
+
     # Specify structure for custom cmake functions
     additional_commands = {
       "foo": {

--- a/cmake_format/format_tests.py
+++ b/cmake_format/format_tests.py
@@ -764,6 +764,27 @@ class TestCanonicalFormatting(unittest.TestCase):
       FoO(bar baz)
       """)
 
+  def test_break_before_args(self):
+    self.config.break_before_args = True
+    self.do_format_test(u"""\
+      # This command should break after every kwarg
+      foo(nonkwarg_a nonkwarg_b HEADERS a.h b.h c.h d.h e.h f.h SOURCES a.cc b.cc d.cc DEPENDS foo bar baz)
+      """, u"""\
+      # This command should break after every kwarg
+      foo(nonkwarg_a nonkwarg_b
+          HEADERS
+            a.h
+            b.h
+            c.h
+            d.h
+            e.h
+            f.h
+          SOURCES
+            a.cc b.cc d.cc
+          DEPENDS
+            foo bar baz)
+      """)
+
   def test_example_file(self):
     thisdir = os.path.dirname(__file__)
     infile_path = os.path.join(thisdir, 'test', 'test_in.cmake')

--- a/cmake_format/formatter.py
+++ b/cmake_format/formatter.py
@@ -68,7 +68,7 @@ def arg_exists_with_comment(args):
 def format_single_arg(config,  # pylint: disable=unused-argument
                       line_width, arg):
   """
-  Return a list of lines that reflow the single arg and all it's comments
+  Return a list of lines that reflow the single arg and all its comments
   into a block with width at most line_width.
   """
   if arg.comments:
@@ -204,7 +204,7 @@ def format_kwarglist(config, line_width, command_name, args):
     return [kwarg] + indent_list(tabbed_indent_str, lines_tabbed)
 
   if not lines_aligned[0]:
-    logging.warn("BUG! format_arglist returned empty firstline!")
+    logging.warn("BUG! format_arglist returned empty first line!")
 
   return ([kwarg + u' ' + lines_aligned[0]]
           + indent_list(aligned_indent_str, lines_aligned[1:]))
@@ -212,14 +212,13 @@ def format_kwarglist(config, line_width, command_name, args):
 
 def format_nonkwarglist(config, line_width, args):
   """
-  Given a list arguments containing no KWARGS, format into a list of lines
+  Given a list of arguments containing no KWARGS, format into a list of lines
   """
   indent_str = ''
   lines = ['']
 
-  # if the there are "lots" of arguments in the list, put one per line,
-  # but we can't reuse the logic below since we do want to append to the
-  # first line.
+  # if there are "lots" of arguments in the list, put one per line, but we
+  # can't reuse the logic below since we do want to append to the first line.
   if len(args) > config.max_subargs_per_line:
     first_lines = format_single_arg(config, line_width - len(indent_str),
                                     args[0])
@@ -386,7 +385,7 @@ def format_command(config, command, line_width):
                           line_width - config.tab_size,
                           command.name, command.body)
 
-    # If the version aligned with the comand start + indent has *alot*
+    # If the version aligned with the comand start + indent has *a lot*
     # fewer lines than the version aligned with the command end, then
     # use this one. Also use it if the first option exceeds line width.
     chosen = None

--- a/cmake_format/formatter.py
+++ b/cmake_format/formatter.py
@@ -199,7 +199,8 @@ def format_kwarglist(config, line_width, command_name, args):
                                   command_name, args[1:])
 
   # If aligned doesn't fit, then use tabbed.
-  if get_block_width(lines_aligned) > line_width - len(aligned_indent_str):
+  if get_block_width(lines_aligned) > line_width - len(aligned_indent_str) \
+     or config.break_before_args:
     return [kwarg] + indent_list(tabbed_indent_str, lines_tabbed)
 
   if not lines_aligned[0]:


### PR DESCRIPTION
This adds a config option named `break_before_args`, which makes the formatter always put a linebreak between a keyword and its arguments. It turns this:
```
          HEADERS a.h
                  b.h
                  c.h
                  d.h
                  e.h
                  f.h
```
into this:
```
          HEADERS
            a.h
            b.h
            c.h
            d.h
            e.h
            f.h
```
I added this because I found myself trying to mess with the line width in order to get this to happen nicely.

There's also a second commit with some comment cleanup.