### PR TITLE
Align kwarg lists

### DIFF
--- a/cmake_format/configuration.py
+++ b/cmake_format/configuration.py
@@ -84,6 +84,7 @@ class Configuration(ConfigObject):
                enum_char=None,
                line_ending=None,
                command_case=None,
+               break_before_args=False,
                additional_commands=None, **_):
 
     self.line_width = line_width
@@ -110,6 +111,8 @@ class Configuration(ConfigObject):
     self.line_ending = get_default(line_ending, u"unix")
     self.command_case = get_default(command_case, u"lower")
     assert self.command_case in (u"lower", u"upper", u"unchanged")
+
+    self.break_before_args = break_before_args
 
     self.additional_commands = get_default(additional_commands, {
         'foo': {
@@ -171,6 +174,8 @@ VARDOCS = {
     "What style line endings to use in the output.",
     "command_case":
     "Format command names consistently as 'lower' or 'upper' case",
+    "break_before_args":
+    "Always add a linebreak between a keyword and its arguments",
     "additional_commands":
     "Specify structure for custom cmake functions"
 }

--- a/cmake_format/configuration.py
+++ b/cmake_format/configuration.py
@@ -85,6 +85,7 @@ class Configuration(ConfigObject):
                line_ending=None,
                command_case=None,
                break_before_args=False,
+               align_kwarg_lists=False,
                additional_commands=None, **_):
 
     self.line_width = line_width
@@ -113,6 +114,8 @@ class Configuration(ConfigObject):
     assert self.command_case in (u"lower", u"upper", u"unchanged")
 
     self.break_before_args = break_before_args
+
+    self.align_kwarg_lists = align_kwarg_lists
 
     self.additional_commands = get_default(additional_commands, {
         'foo': {
@@ -164,7 +167,7 @@ VARDOCS = {
     "If true, separate function names from parentheses with a space",
     "dangle_parens":
     "If a statement is wrapped to more than one line, than dangle the closing"
-    " parenthesis on it's own line",
+    " parenthesis on its own line",
     "bullet_char":
     "What character to use for bulleted lists",
     "enum_char":
@@ -176,6 +179,8 @@ VARDOCS = {
     "Format command names consistently as 'lower' or 'upper' case",
     "break_before_args":
     "Always add a linebreak between a keyword and its arguments",
+    "align_kwarg_lists":
+    "Indent all argument lists to match the longest keyword argument",
     "additional_commands":
     "Specify structure for custom cmake functions"
 }

--- a/cmake_format/doc/README.rst
+++ b/cmake_format/doc/README.rst
@@ -98,6 +98,9 @@ pleasant way.
     # "unchanged"
     command_case = u'lower'
 
+    # Always add a linebreak between a keyword and its arguments
+    break_before_args = False
+
     # Specify structure for custom cmake functions
     additional_commands = {
       "foo": {

--- a/cmake_format/doc/README.rst
+++ b/cmake_format/doc/README.rst
@@ -101,6 +101,9 @@ pleasant way.
     # Always add a linebreak between a keyword and its arguments
     break_before_args = False
 
+    # Indent all argument lists to match the longest keyword argument
+    align_kwarg_lists = False
+
     # Specify structure for custom cmake functions
     additional_commands = {
       "foo": {

--- a/cmake_format/format_tests.py
+++ b/cmake_format/format_tests.py
@@ -764,6 +764,27 @@ class TestCanonicalFormatting(unittest.TestCase):
       FoO(bar baz)
       """)
 
+  def test_break_before_args(self):
+    self.config.break_before_args = True
+    self.do_format_test(u"""\
+      # This command should break after every kwarg
+      foo(nonkwarg_a nonkwarg_b HEADERS a.h b.h c.h d.h e.h f.h SOURCES a.cc b.cc d.cc DEPENDS foo bar baz)
+      """, u"""\
+      # This command should break after every kwarg
+      foo(nonkwarg_a nonkwarg_b
+          HEADERS
+            a.h
+            b.h
+            c.h
+            d.h
+            e.h
+            f.h
+          SOURCES
+            a.cc b.cc d.cc
+          DEPENDS
+            foo bar baz)
+      """)
+
   def test_example_file(self):
     thisdir = os.path.dirname(__file__)
     infile_path = os.path.join(thisdir, 'test', 'test_in.cmake')

--- a/cmake_format/format_tests.py
+++ b/cmake_format/format_tests.py
@@ -32,7 +32,8 @@ class TestCanonicalFormatting(unittest.TestCase):
                           'foo', flags=['BAR', 'BAZ'], kwargs={
                               "HEADERS": '*',
                               "SOURCES": '*',
-                              "DEPENDS": '*'
+                              "DEPENDS": '*',
+                              "LONG_KWARG": '*',
                           })
 
   def tearDown(self):
@@ -783,6 +784,44 @@ class TestCanonicalFormatting(unittest.TestCase):
             a.cc b.cc d.cc
           DEPENDS
             foo bar baz)
+      """)
+
+  def test_align_kwarg_lists(self):
+    self.config.align_kwarg_lists = True
+    self.do_format_test(u"""\
+      # This command should align all arg lists
+      foo(nonkwarg_a nonkwarg_b HEADERS a.h b.h c.h d.h e.h f.h SOURCES a.cc b.cc d.cc LONG_KWARG foo bar baz)
+      """, u"""\
+      # This command should align all arg lists
+      foo(nonkwarg_a nonkwarg_b
+          HEADERS    a.h
+                     b.h
+                     c.h
+                     d.h
+                     e.h
+                     f.h
+          SOURCES    a.cc b.cc d.cc
+          LONG_KWARG foo bar baz)
+      """)
+
+    self.config.break_before_args = True
+    self.do_format_test(u"""\
+      # This command should align all arg lists on a new line
+      foo(nonkwarg_a nonkwarg_b HEADERS a.h b.h c.h d.h e.h f.h SOURCES a.cc b.cc d.cc LONG_KWARG foo bar baz)
+      """, u"""\
+      # This command should align all arg lists on a new line
+      foo(nonkwarg_a nonkwarg_b
+          HEADERS
+                    a.h
+                    b.h
+                    c.h
+                    d.h
+                    e.h
+                    f.h
+          SOURCES
+                    a.cc b.cc d.cc
+          LONG_KWARG
+                    foo bar baz)
       """)
 
   def test_example_file(self):

--- a/cmake_format/formatter.py
+++ b/cmake_format/formatter.py
@@ -68,7 +68,7 @@ def arg_exists_with_comment(args):
 def format_single_arg(config,  # pylint: disable=unused-argument
                       line_width, arg):
   """
-  Return a list of lines that reflow the single arg and all it's comments
+  Return a list of lines that reflow the single arg and all its comments
   into a block with width at most line_width.
   """
   if arg.comments:
@@ -204,7 +204,7 @@ def format_kwarglist(config, line_width, command_name, args):
     return [kwarg] + indent_list(tabbed_indent_str, lines_tabbed)
 
   if not lines_aligned[0]:
-    logging.warn("BUG! format_arglist returned empty firstline!")
+    logging.warn("BUG! format_arglist returned empty first line!")
 
   return ([kwarg + u' ' + lines_aligned[0]]
           + indent_list(aligned_indent_str, lines_aligned[1:]))
@@ -212,14 +212,13 @@ def format_kwarglist(config, line_width, command_name, args):
 
 def format_nonkwarglist(config, line_width, args):
   """
-  Given a list arguments containing no KWARGS, format into a list of lines
+  Given a list of arguments containing no KWARGS, format into a list of lines
   """
   indent_str = ''
   lines = ['']
 
-  # if the there are "lots" of arguments in the list, put one per line,
-  # but we can't reuse the logic below since we do want to append to the
-  # first line.
+  # if there are "lots" of arguments in the list, put one per line, but we
+  # can't reuse the logic below since we do want to append to the first line.
   if len(args) > config.max_subargs_per_line:
     first_lines = format_single_arg(config, line_width - len(indent_str),
                                     args[0])
@@ -386,7 +385,7 @@ def format_command(config, command, line_width):
                           line_width - config.tab_size,
                           command.name, command.body)
 
-    # If the version aligned with the comand start + indent has *alot*
+    # If the version aligned with the comand start + indent has *a lot*
     # fewer lines than the version aligned with the command end, then
     # use this one. Also use it if the first option exceeds line width.
     chosen = None

--- a/cmake_format/formatter.py
+++ b/cmake_format/formatter.py
@@ -199,7 +199,8 @@ def format_kwarglist(config, line_width, command_name, args):
                                   command_name, args[1:])
 
   # If aligned doesn't fit, then use tabbed.
-  if get_block_width(lines_aligned) > line_width - len(aligned_indent_str):
+  if get_block_width(lines_aligned) > line_width - len(aligned_indent_str) \
+     or config.break_before_args:
     return [kwarg] + indent_list(tabbed_indent_str, lines_tabbed)
 
   if not lines_aligned[0]:

--- a/cmake_format/formatter.py
+++ b/cmake_format/formatter.py
@@ -40,7 +40,7 @@ def split_args_by_kwargs(fn_spec, command_name, args):
   """
   Takes in a list of arguments and returns a list of lists. Each sublist
   is either a list of positional arguments, a list containg a kwarg
-  followed by it's sub arguments, or a list containing a consecutive
+  followed by its sub arguments, or a list containing a consecutive
   sequence of flags.
   """
   arg_split = [[]]
@@ -55,6 +55,18 @@ def split_args_by_kwargs(fn_spec, command_name, args):
     arg_split[-1].append(arg)
 
   return arg_split
+
+
+def get_max_kwarg_length(fn_spec, command_name, arg_split):
+  """
+  Takes in a split list of arguments, and returns the length of the longest
+  kwarg.
+  """
+  max_kwarg_length = 0
+  for arglist in arg_split:
+    if is_kwarg(fn_spec, command_name, arglist[0].contents):
+      max_kwarg_length = max(max_kwarg_length, len(arglist[0].contents))
+  return max_kwarg_length
 
 
 def arg_exists_with_comment(args):
@@ -127,7 +139,7 @@ def format_shell_command(config, line_width, command_name, args):
 
   for arg_sublist in arg_multilist_filtered:
     sublist_lines = format_arglist(config, line_width, command_name,
-                                   arg_sublist)
+                                   arg_sublist, None)
     lines.extend(sublist_lines)
 
   return lines
@@ -151,7 +163,7 @@ def join_parens(args):
   return out
 
 
-def format_kwarglist(config, line_width, command_name, args):
+def format_kwarglist(config, line_width, command_name, args, indent):
   """
   Given a list of arguments containing a KWARG in position [0], format into
   a list of lines.
@@ -161,6 +173,9 @@ def format_kwarglist(config, line_width, command_name, args):
   if len(args) == 1:
     return [kwarg]
 
+  aligned_indent_str = u' ' + u' ' * (indent or len(kwarg))
+  tabbed_indent_str = u' ' * (indent or config.tab_size)
+
   # If the KWARG is 'COMMAND' then let's not put one entry per line,
   # but fit as many command args per line as possible.
   if kwarg == u'COMMAND':
@@ -168,9 +183,6 @@ def format_kwarglist(config, line_width, command_name, args):
     config = config.clone()
     # pylint: disable=attribute-defined-outside-init
     config.max_subargs_per_line = 1e6
-
-    aligned_indent_str = u' ' * (len(kwarg) + 1)
-    tabbed_indent_str = u' ' * config.tab_size
 
     # Lines to append if we put them aligned with the end of the kwarg
     line_width_aligned = line_width - len(aligned_indent_str)
@@ -184,19 +196,16 @@ def format_kwarglist(config, line_width, command_name, args):
                                         args[1].contents, args[1:])
 
   else:
-    aligned_indent_str = u' ' * (len(kwarg) + 1)
-    tabbed_indent_str = u' ' * config.tab_size
-
     # Lines to append if we put them aligned with the end of the kwarg
     line_width_aligned = line_width - len(aligned_indent_str)
     lines_aligned = format_arglist(config, line_width_aligned,
-                                   command_name, args[1:])
+                                   command_name, args[1:], None)
 
     # Lines to append if we put them on lines after the kwarg and
     # indented one block higher
     line_width_tabbed = line_width - len(tabbed_indent_str)
     lines_tabbed = format_arglist(config, line_width_tabbed,
-                                  command_name, args[1:])
+                                  command_name, args[1:], None)
 
   # If aligned doesn't fit, then use tabbed.
   if get_block_width(lines_aligned) > line_width - len(aligned_indent_str) \
@@ -206,7 +215,11 @@ def format_kwarglist(config, line_width, command_name, args):
   if not lines_aligned[0]:
     logging.warn("BUG! format_arglist returned empty first line!")
 
-  return ([kwarg + u' ' + lines_aligned[0]]
+  kwarg_arg_gap = u' '
+  if indent:
+    kwarg_arg_gap += u' ' * (indent - len(kwarg))
+
+  return ([kwarg + kwarg_arg_gap + lines_aligned[0]]
           + indent_list(aligned_indent_str, lines_aligned[1:]))
 
 
@@ -277,16 +290,16 @@ def format_nonkwarglist(config, line_width, args):
   return lines
 
 
-def format_arglist(config, line_width, command_name, args):
+def format_arglist(config, line_width, command_name, args, indent):
   """
-  Given a list arguments containing at most one KWARG (in position [0]
+  Given a list of arguments containing at most one KWARG (in position [0]
   if it exists), format into a list of lines.
   """
   if len(args) < 1:
     return []
 
   if is_kwarg(config.fn_spec, command_name, args[0].contents):
-    return format_kwarglist(config, line_width, command_name, args)
+    return format_kwarglist(config, line_width, command_name, args, indent)
 
   return format_nonkwarglist(config, line_width, args)
 
@@ -315,16 +328,21 @@ def format_args(config, line_width, command_name, args):
     else:
       arg_multilist_filtered.append(arg_sublist)
 
+  max_kwarg_length = None
+  if config.align_kwarg_lists:
+    max_kwarg_length = get_max_kwarg_length(config.fn_spec, command_name,
+                                            arg_multilist_filtered)
+
   for idx, arg_sublist in enumerate(arg_multilist_filtered):
     if idx + 1 == len(arg_multilist_filtered):
       # NOTE(josh): reserve one character in the final arglist for the
       # parenthesis. This is not the right way to deal with this problem
       # but it'll work until the tree-format refactor.
       sublist_lines = format_arglist(config, line_width - 1, command_name,
-                                     arg_sublist)
+                                     arg_sublist, max_kwarg_length)
     else:
       sublist_lines = format_arglist(config, line_width, command_name,
-                                     arg_sublist)
+                                     arg_sublist, max_kwarg_length)
     lines.extend(sublist_lines)
 
   return lines


### PR DESCRIPTION
(This is based on top of #35, so just look at the last commit. I can rebase if you like.)

This adds a config option to align lists of arguments across kwargs. It turns this:
```
          HEADERS a.h
                  b.h
                  c.h
                  d.h
                  e.h
                  f.h
          SOURCES a.cc b.cc d.cc
          LONG_KWARG foo bar baz)
```
into this:
```
          HEADERS    a.h
                     b.h
                     c.h
                     d.h
                     e.h
                     f.h
          SOURCES    a.cc b.cc d.cc
          LONG_KWARG foo bar baz)

```

It also interacts correctly with #35 if you want something like this:
```
          HEADERS
                    a.h
                    b.h
                    c.h
                    d.h
                    e.h
                    f.h
          SOURCES
                    a.cc b.cc d.cc
          LONG_KWARG
                    foo bar baz)
```