### PR TITLE
--dump-config dumps the current configuration

### DIFF
--- a/cmake_format/__main__.py
+++ b/cmake_format/__main__.py
@@ -150,7 +150,10 @@ def dump_config(outfmt, outfile):
   Dump the default configuration to stdout
   """
 
-  cfg = configuration.Configuration()
+  config_dict = get_config(os.getcwd(), None)
+
+  cfg = configuration.Configuration(**config_dict)
+
   if outfmt == 'yaml':
     import yaml
     yaml.dump(cfg.as_dict(), sys.stdout, indent=2,
@@ -204,7 +207,7 @@ def main():
 
   mutex = arg_parser.add_mutually_exclusive_group()
   mutex.add_argument('--dump-config', choices=['yaml', 'json', 'python'],
-                     help='If specified, print the default configuration to '
+                     help='If specified, print the current configuration to '
                           'stdout and exit')
   mutex.add_argument('-i', '--in-place', action='store_true')
   mutex.add_argument('-o', '--outfile-path', default=None,
@@ -249,6 +252,8 @@ def main():
   args = arg_parser.parse_args()
 
   if args.dump_config:
+    assert not args.infilepaths, \
+      "Error: can't supply input files when dumping config."
     dump_config(args.dump_config, sys.stdout)
     sys.exit(0)
 

--- a/cmake_format/doc/README.rst
+++ b/cmake_format/doc/README.rst
@@ -37,7 +37,7 @@ Usage
     optional arguments:
       -h, --help            show this help message and exit
       --dump-config {yaml,json,python}
-                            If specified, print the default configuration to
+                            If specified, print the current configuration to
                             stdout and exit
       -i, --in-place
       -o OUTFILE_PATH, --outfile-path OUTFILE_PATH
@@ -124,7 +124,7 @@ A automatically detected configuration files may have any name that matches
 If you'd like to create a new configuration file, ``cmake-format`` can help
 by dumping out the default configuration in your preferred format. You can run
 ``cmake-format --dump-config [yaml|json|python]`` to print the default
-configuration ``stdout`` and use that as a starting point.
+configuration to ``stdout`` and use that as a starting point.
 
 -------
 Markup


### PR DESCRIPTION
This means if there's no format config file found, it prints the default config, but if it does find a config file it prints that config. Very helpful for debugging.
It also asserts if you try to supply an input file while dumping. Both before and now the input files are ignored, but with this change it's more important to make this obvious -- you might want it to print the config of the provided file, but it's hard to know what to do if multiple files are provided. They probably don't want a bunch of configs printed. I'm definitely open to changes here, though.