### PR TITLE
Add more options for dangling parentheses

### DIFF
--- a/cmake_format/configuration.py
+++ b/cmake_format/configuration.py
@@ -79,7 +79,7 @@ class Configuration(ConfigObject):
                max_subargs_per_line=3,
                separate_ctrl_name_with_space=False,
                separate_fn_name_with_space=False,
-               dangle_parens=False,
+               dangle_parens='never',
                bullet_char=None,
                enum_char=None,
                line_ending=None,
@@ -147,6 +147,7 @@ class Configuration(ConfigObject):
 VARCHOICES = {
     'line_ending': ['windows', 'unix', 'auto'],
     'command_case': ['lower', 'upper', 'unchanged'],
+    'dangle_parens': ['never', 'wrapped', 'always'],
 }
 
 VARDOCS = {
@@ -160,8 +161,8 @@ VARDOCS = {
     "separate_fn_name_with_space":
     "If true, separate function names from parentheses with a space",
     "dangle_parens":
-    "If a statement is wrapped to more than one line, than dangle the closing"
-    " parenthesis on it's own line",
+    "Put the end parenthesis on the next line either never, or when a"
+    " statement is wrapped to more than one line, or always",
     "bullet_char":
     "What character to use for bulleted lists",
     "enum_char":

--- a/cmake_format/configuration.py
+++ b/cmake_format/configuration.py
@@ -80,6 +80,7 @@ class Configuration(ConfigObject):
                separate_ctrl_name_with_space=False,
                separate_fn_name_with_space=False,
                dangle_parens='never',
+               dangle_parens_alignment='left',
                bullet_char=None,
                enum_char=None,
                line_ending=None,
@@ -98,6 +99,7 @@ class Configuration(ConfigObject):
     self.separate_ctrl_name_with_space = separate_ctrl_name_with_space
     self.separate_fn_name_with_space = separate_fn_name_with_space
     self.dangle_parens = dangle_parens
+    self.dangle_parens_alignment = dangle_parens_alignment
 
     self.bullet_char = str(bullet_char)[0]
     if bullet_char is None:
@@ -148,6 +150,7 @@ VARCHOICES = {
     'line_ending': ['windows', 'unix', 'auto'],
     'command_case': ['lower', 'upper', 'unchanged'],
     'dangle_parens': ['never', 'wrapped', 'always'],
+    'dangle_parens_alignment': ['left', 'parens', 'contents'],
 }
 
 VARDOCS = {
@@ -163,6 +166,9 @@ VARDOCS = {
     "dangle_parens":
     "Put the end parenthesis on the next line either never, or when a"
     " statement is wrapped to more than one line, or always",
+    "dangle_parens_alignment":
+    "When dangling parentheses, whether they should they be left-aligned, or"
+    " aligned with the open paren, or with the contents of the command",
     "bullet_char":
     "What character to use for bulleted lists",
     "enum_char":

--- a/cmake_format/doc/README.rst
+++ b/cmake_format/doc/README.rst
@@ -85,6 +85,10 @@ pleasant way.
     # statement is wrapped to more than one line, or always
     dangle_parens = 'never'
 
+    # When dangling parentheses, whether they should they be left-aligned, or
+    # aligned with the open paren, or with the contents of the command
+    dangle_parens_alignment = 'left'
+
     # What character to use for bulleted lists
     bullet_char = u'*'
 

--- a/cmake_format/doc/README.rst
+++ b/cmake_format/doc/README.rst
@@ -81,9 +81,9 @@ pleasant way.
     # If true, separate function names from parentheses with a space
     separate_fn_name_with_space = False
 
-    # If a statement is wrapped to more than one line, than dangle the closing
-    # parenthesis on it's own line
-    dangle_parens = False
+    # Put the end parenthesis on the next line either never, or when a
+    # statement is wrapped to more than one line, or always
+    dangle_parens = 'never'
 
     # What character to use for bulleted lists
     bullet_char = u'*'

--- a/cmake_format/format_tests.py
+++ b/cmake_format/format_tests.py
@@ -707,6 +707,88 @@ class TestCanonicalFormatting(unittest.TestCase):
       )
     """)
 
+  def test_dangle_parens_alignment(self):
+    self.config.dangle_parens = 'always'
+    self.config.dangle_parens_alignment = 'contents'
+    self.do_format_test(u"""\
+      foo_command()
+      foo_command(arg1)
+      foo_command(arg1) # comment
+    """, u"""\
+      foo_command()
+      foo_command(arg1)
+      foo_command(arg1) # comment
+    """)
+
+    self.do_format_test(u"""\
+      some_long_command_name(longargname longargname longargname longargname longargname)
+    """, u"""\
+      some_long_command_name(
+        longargname longargname longargname longargname longargname
+        )
+    """)
+
+    self.do_format_test(u"""\
+      if(foo)
+        some_long_command_name(longargname longargname longargname longargname longargname)
+      endif()
+    """, u"""\
+      if(foo)
+        some_long_command_name(
+          longargname longargname longargname longargname longargname
+          )
+      endif()
+    """)
+
+    self.do_format_test(u"""\
+      some_long_command_name(longargname longargname longargname longargname longargname longargname longargname longargname)
+    """, u"""\
+      some_long_command_name(longargname
+                             longargname
+                             longargname
+                             longargname
+                             longargname
+                             longargname
+                             longargname
+                             longargname
+                             )
+    """)
+
+    self.do_format_test(u"""\
+      target_include_directories(target INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
+      """, u"""\
+      target_include_directories(
+        target INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
+        )
+      """)
+
+    self.config.dangle_parens_alignment = 'parens'
+    self.do_format_test(u"""\
+      if(foo)
+        some_long_command_name(longargname longargname longargname longargname longargname)
+      endif()
+    """, u"""\
+      if(foo)
+        some_long_command_name(
+          longargname longargname longargname longargname longargname
+          )
+      endif()
+    """)
+
+    self.do_format_test(u"""\
+      some_long_command_name(longargname longargname longargname longargname longargname longargname longargname longargname)
+    """, u"""\
+      some_long_command_name(longargname
+                             longargname
+                             longargname
+                             longargname
+                             longargname
+                             longargname
+                             longargname
+                             longargname
+                            )
+    """)
+
   def test_windows_line_endings_input(self):
     self.do_format_test(
         u"      #[[*********************************************\r\n"

--- a/cmake_format/format_tests.py
+++ b/cmake_format/format_tests.py
@@ -640,7 +640,7 @@ class TestCanonicalFormatting(unittest.TestCase):
     """)
 
   def test_dangle_parens(self):
-    self.config.dangle_parens = True
+    self.config.dangle_parens = 'wrapped'
     self.do_format_test(u"""\
       foo_command()
       foo_command(arg1)
@@ -691,6 +691,21 @@ class TestCanonicalFormatting(unittest.TestCase):
         target INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>
       )
       """)
+
+    self.config.dangle_parens = 'always'
+    self.do_format_test(u"""\
+      some_long_command_name(longargname longargname longargname longargname longargname longargname longargname longargname)
+    """, u"""\
+      some_long_command_name(longargname
+                             longargname
+                             longargname
+                             longargname
+                             longargname
+                             longargname
+                             longargname
+                             longargname
+      )
+    """)
 
   def test_windows_line_endings_input(self):
     self.do_format_test(

--- a/cmake_format/formatter.py
+++ b/cmake_format/formatter.py
@@ -414,7 +414,21 @@ def format_command(config, command, line_width):
               and not command.body[-1].comments):
         lines[-1] += u')'
       else:
-        lines.append(u')')
+        if config.dangle_parens_alignment == 'left':
+          indent_str = u''
+        else:
+          if chosen is lines_b:
+            # If we're using lines_b, then using 'parens' doesn't make sense
+            # because the end parenthesis would be indented past the contents
+            # of the command. Instead fall back to matching the indent of the
+            # contents, which in this case is just the tab size.
+            indent_str = u' ' * config.tab_size
+          else:
+            if config.dangle_parens_alignment == 'parens':
+              indent_str = u' ' * (len(command_start) - 1)
+            elif config.dangle_parens_alignment == 'contents':
+              indent_str = u' ' * (len(command_start))
+        lines.append(indent_str + u')')
     else:
       if len(lines[-1]) < line_width and not command.body[-1].comments:
         lines[-1] += u')'

--- a/cmake_format/formatter.py
+++ b/cmake_format/formatter.py
@@ -405,7 +405,8 @@ def format_command(config, command, line_width):
       for line in lines_a[1:]:
         lines.append(indent_str + line)
 
-    if chosen is lines_b and config.dangle_parens:
+    if (chosen is lines_b and config.dangle_parens == 'wrapped') \
+       or config.dangle_parens == 'always':
       # If we're configured to dangle newlines but there's one line worth of
       # stuff then don't dangle
       if (len(lines) == 1 and len(lines[-1]) < line_width


### PR DESCRIPTION
The first commit here isn't backward-compatible because it changes an option time from bool to string. Let me know your thoughts.

Adds:
 - 'always' option for dangling parentheses
 - 'left', 'parens', and 'contents' options for how to align these parentheses.

Left:
```
      some_long_command_name(longargname
                             longargname
      )
```
Parens:
```
      some_long_command_name(longargname
                             longargname
                            )
```
Contents:
```
      some_long_command_name(longargname
                             longargname
                             )
```

Fixes #32.