### PR TITLE
Always wrap kwargs for certain functions

### DIFF
--- a/cmake_format/commands.py
+++ b/cmake_format/commands.py
@@ -7,7 +7,7 @@ ONE_OR_MORE = '+'
 
 
 class FnSpec:
-  def __init__(self, pargs=None, flags=None, kwargs=None):
+  def __init__(self, pargs=None, flags=None, kwargs=None, always_wrap=False):
     if pargs is None:
       pargs = 0
     if flags is None:
@@ -18,6 +18,12 @@ class FnSpec:
     self._kwargs = dict(kwargs)
     self._pargs = pargs
     self._flags = flags
+    self._always_wrap = always_wrap
+
+  @property
+  def always_wrap(self):
+    """Return true if this function's kwargs should always be wrapped."""
+    return self._always_wrap
 
   def is_flag(self, arg):
     """Return true if the given argument is a flag."""
@@ -28,8 +34,9 @@ class FnSpec:
     return arg in self._kwargs
 
 
-def decl_command(fn_spec, command_name, pargs=None, flags=None, kwargs=None):
-  fn_spec[command_name] = FnSpec(pargs, flags, kwargs)
+def decl_command(fn_spec, command_name, pargs=None, flags=None, kwargs=None,
+                 always_wrap=False):
+  fn_spec[command_name] = FnSpec(pargs, flags, kwargs, always_wrap)
 
 
 def get_fn_spec():

--- a/cmake_format/commands.py
+++ b/cmake_format/commands.py
@@ -6,19 +6,30 @@ ZERO_OR_MORE = '*'
 ONE_OR_MORE = '+'
 
 
-def decl_command(fn_spec, command_name, pargs=None, flags=None, kwargs=None):
-  if pargs is None:
-    pargs = 0
-  if flags is None:
-    flags = []
-  if kwargs is None:
-    kwargs = {}
+class FnSpec:
+  def __init__(self, pargs=None, flags=None, kwargs=None):
+    if pargs is None:
+      pargs = 0
+    if flags is None:
+      flags = []
+    if kwargs is None:
+      kwargs = {}
 
-  decl = dict(kwargs)
-  decl['pargs'] = pargs
-  for flag in flags:
-    decl[flag] = 0
-  fn_spec[command_name] = decl
+    self._kwargs = dict(kwargs)
+    self._pargs = pargs
+    self._flags = flags
+
+  def is_flag(self, arg):
+    """Return true if the given argument is a flag."""
+    return arg in self._flags
+
+  def is_kwarg(self, arg):
+    """Return true if the given argument is a kwarg."""
+    return arg in self._kwargs
+
+
+def decl_command(fn_spec, command_name, pargs=None, flags=None, kwargs=None):
+  fn_spec[command_name] = FnSpec(pargs, flags, kwargs)
 
 
 def get_fn_spec():

--- a/cmake_format/configuration.py
+++ b/cmake_format/configuration.py
@@ -113,6 +113,7 @@ class Configuration(ConfigObject):
 
     self.additional_commands = get_default(additional_commands, {
         'foo': {
+            'always_wrap': False,
             'flags': ['BAR', 'BAZ'],
             'kwargs': {
                 'HEADERS': '*',

--- a/cmake_format/format_tests.py
+++ b/cmake_format/format_tests.py
@@ -130,6 +130,24 @@ class TestCanonicalFormatting(unittest.TestCase):
           source_g.cc)
       """)
 
+  def test_always_wrap(self):
+    commands.decl_command(self.config.fn_spec,
+                          'always_wrap',  always_wrap=True,
+                              flags=['BAR', 'BAZ'],
+                              kwargs={
+                                  "HEADERS": '*',
+                                  "SOURCES": '*',
+                                  "DEPENDS": '*'
+                          })
+    self.do_format_test(u"""\
+      # This short command should be split to multiple lines
+      always_wrap(HEADERS a.h b.h c.h SOURCES a.c b.c c.c)
+      """, u"""\
+      # This short command should be split to multiple lines
+      always_wrap(HEADERS a.h b.h c.h
+                  SOURCES a.c b.c c.c)
+      """)
+
   # TODO(josh): figure out why this test elicits different behavior than the
   # whole-file demo.
   def test_string_preserved_during_split(self):

--- a/cmake_format/formatter.py
+++ b/cmake_format/formatter.py
@@ -26,6 +26,13 @@ def format_comment_block(config, line_width,  # pylint: disable=unused-argument
           for line in markup.format_items(config, line_width - 2, items)]
 
 
+def always_wrap(fn_spec, command_name):
+  """Return true if this function's kwargs should always be wrapped."""
+  if command_name in fn_spec:
+    return fn_spec[command_name].always_wrap
+  return False
+
+
 def is_flag(fn_spec, command_name, arg):
   """Return true if the given argument is a flag."""
   if command_name in fn_spec:
@@ -299,8 +306,10 @@ def format_args(config, line_width, command_name, args):
   """Format arguments into a block with at most line_width chars."""
 
   # If there are no arguments that contain a comment, then attempt to
-  # pack all of the arguments onto a single line
-  if not arg_exists_with_comment(args):
+  # pack all of the arguments onto a single line if our config allows
+  # that for this command.
+  if not arg_exists_with_comment(args) \
+     and not always_wrap(config.fn_spec, command_name):
     single_line = u' '.join(join_parens([arg.contents for arg in args]))
     if len(single_line) < line_width:
       return [single_line]

--- a/cmake_format/formatter.py
+++ b/cmake_format/formatter.py
@@ -28,12 +28,16 @@ def format_comment_block(config, line_width,  # pylint: disable=unused-argument
 
 def is_flag(fn_spec, command_name, arg):
   """Return true if the given argument is a flag."""
-  return fn_spec.get(command_name, {}).get(arg, 1) == 0
+  if command_name in fn_spec:
+    return fn_spec[command_name].is_flag(arg)
+  return False
 
 
 def is_kwarg(fn_spec, command_name, arg):
   """Return true if the given argument is a kwarg."""
-  return fn_spec.get(command_name, {}).get(arg, 0) != 0
+  if command_name in fn_spec:
+    return fn_spec[command_name].is_kwarg(arg)
+  return False
 
 
 def split_args_by_kwargs(fn_spec, command_name, args):


### PR DESCRIPTION
This turns this:
```
      always_wrap(HEADERS a.h b.h c.h SOURCES a.c b.c c.c)
```
into this:
```
      always_wrap(HEADERS a.h b.h c.h
                  SOURCES a.c b.c c.c)
```
Combined with `max_subargs_per_line: 1`, you can make it always put just one argument per line, which ends up with a nice consistent formatting regardless of argument number.
It also makes a new class, FnSpec, to hold more detail about functions if we want to format them specially.