### PR TITLE
Extend Specification for CMake Commands

### DIFF
--- a/cmake_format/commands.py
+++ b/cmake_format/commands.py
@@ -379,6 +379,7 @@ def get_fn_spec():
           "INCLUDES": ZERO_OR_MORE,
           "INCLUDESPERMISSIONS": ZERO_OR_MORE,
           "LIBRARY": subspec,
+          "NAMESPACE": 1,
           "PATTERN": ZERO_OR_MORE,
           "PRIVATE_HEADER": subspec,
           "PROGRAMS": ZERO_OR_MORE,

--- a/cmake_format/commands.py
+++ b/cmake_format/commands.py
@@ -189,6 +189,18 @@ def get_fn_spec():
       })
 
   fn_spec.add(
+      "export",
+      flags=["APPEND", "EXPORT_LINK_INTERFACE_LIBRARIES"],
+      kwargs={
+          "ANDROID_MK": 1,
+          "EXPORT": 1,
+          "FILE": 1,
+          "NAMESPACE": 1,
+          "PACKAGE": 1,
+          "TARGETS": ONE_OR_MORE
+      })
+
+  fn_spec.add(
       "file",
       flags=["FOLLOW_SYMLINKS", "GENERATE", "HEX", "NEWLINE_CONSUME",
              "NO_HEX_CONVERSION", "SHOW_PROGRESS", "UTC"],

--- a/cmake_format/commands.py
+++ b/cmake_format/commands.py
@@ -522,7 +522,16 @@ def get_fn_spec():
       "if", flags=[], kwargs={
           "NOT": ONE_OR_MORE,
           "AND": ONE_OR_MORE,
-          "OR": ONE_OR_MORE
+          "OR": ONE_OR_MORE,
+          "COMMAND": 1,
+          "DEFINED": 1,
+          "EXISTS": 1,
+          "IS_ABSOLUTE": 1,
+          "IS_DIRECTORY": 1,
+          "IS_SYMLINK": 1,
+          "POLICY": 1,
+          "TARGET": 1,
+          "TEST": 1
       }
   )
 

--- a/cmake_format/commands.py
+++ b/cmake_format/commands.py
@@ -355,6 +355,7 @@ def get_fn_spec():
       kwargs={
           "ARCHIVE": subspec,
           "BUNDLE": subspec,
+          "DESTINATION": 1,
           "DIRECTORY": ZERO_OR_MORE,
           "DIRECTORY_PERMISSIONS": ZERO_OR_MORE,
           "EXCLUDE": ONE_OR_MORE,

--- a/cmake_format/commands.py
+++ b/cmake_format/commands.py
@@ -512,6 +512,12 @@ def get_fn_spec():
       })
 
   fn_spec.add(
+      "write_basic_package_version_file", flags=[], kwargs={
+          "COMPATIBILITY": 1,
+          "VERSION": 1
+      })
+
+  fn_spec.add(
       "if", flags=[], kwargs={
           "NOT": ONE_OR_MORE,
           "AND": ONE_OR_MORE,


### PR DESCRIPTION
This PR extends the specification for some builtin CMake commands. It should improve the formatting for the commands

- `if`
- `install`, 
- `export`, and
- `write_basic_package_version_file`

a little bit.

If I should change anything in this pull request, then please just comment below. Thank you.