### PR TITLE
Fix comment handling in kwarg groups.

### DIFF
--- a/cmake_format/format_tests.py
+++ b/cmake_format/format_tests.py
@@ -213,6 +213,20 @@ class TestCanonicalFormatting(unittest.TestCase):
                             ${ARGN})
     """)
 
+  def test_argcomments_force_reflow_trailing_comment(self):
+    self.config.line_width = 140
+    self.do_format_test("""\
+      find_package(foobar REQUIRED
+             COMPONENTS some_component
+                # some_other_component # This is a very long comment, and actually the second comment in this row.
+          )
+    """, """\
+      find_package(foobar REQUIRED
+                   COMPONENTS some_component
+                              # some_other_component # This is a very long comment, and actually the second comment in this row.
+                   )
+    """)
+
   def test_format_off(self):
     self.do_format_test("""\
       # This part of the comment should

--- a/cmake_format/formatter.py
+++ b/cmake_format/formatter.py
@@ -628,6 +628,10 @@ class StatementNode(LayoutNode):
 class KwargGroupNode(LayoutNode):
 
   def has_terminal_comment(self):
+    # TODO(siedenc): Josh, do you prefer to do this check here, or should
+    # CommentNode.has_terminal_comment() return True?
+    if self.children[-1].type == NodeType.COMMENT:
+      return True
     return self.children[-1].has_terminal_comment()
 
   def _reflow(self, config, cursor, passno):


### PR DESCRIPTION
Extend 'has_trailing_comment' check to trailing comments in
`KwargsGroupNodes` where the last child is a `CommentNode`.

There is a TODO because I do not know whether this implementation should
be preferred over just overloading `has_trailing_comment` as `return
True` in `CommentNode`.

Fixes #56