### PR TITLE
Add missing keyword arguments to project command

### DIFF
--- a/cmake_format/commands.py
+++ b/cmake_format/commands.py
@@ -456,6 +456,8 @@ def get_fn_spec():
 
   fn_spec.add(
       "project", flags=[], kwargs={
+          "DESCRIPTION": 1,
+          "HOMEPAGE_URL": 1,
           "LANGUAGES": ZERO_OR_MORE,
           "VERSION": ZERO_OR_MORE
       })


### PR DESCRIPTION
The `project` command learned the new keyword arguments `DESCRIPTION` in cmake 3.9 and `HOMEPAGE_URL` in cmake 3.12.

This pull request adds those keyword arguments to cmake-format.