### PR TITLE
add config option keep_comment_line_blocks

### DIFF
--- a/cmake_format/configuration.py
+++ b/cmake_format/configuration.py
@@ -94,6 +94,7 @@ class Configuration(ConfigObject):
                enable_markup=True,
                first_comment_is_literal=False,
                literal_comment_pattern=None,
+               keep_comment_line_blocks=True,
                fence_pattern=None,
                ruler_pattern=None,
                emit_byteorder_mark=False,
@@ -144,6 +145,7 @@ class Configuration(ConfigObject):
     self.enable_markup = enable_markup
     self.first_comment_is_literal = first_comment_is_literal
     self.literal_comment_pattern = literal_comment_pattern
+    self.keep_comment_line_blocks = keep_comment_line_blocks
     self.fence_pattern = get_default(fence_pattern, markup.FENCE_PATTERN)
     self.ruler_pattern = get_default(ruler_pattern, markup.RULER_PATTERN)
     self.emit_byteorder_mark = emit_byteorder_mark
@@ -242,6 +244,12 @@ VARDOCS = {
     "literal_comment_pattern":
     "If comment markup is enabled, don't reflow any comment block which matches"
     "this (regex) pattern. Default is `None` (disabled).",
+    "keep_comment_line_blocks":
+    "Lines that are a sequence of 3 or more # characters only (match ^#{3}#*$) "
+    "will be kept as is as long as they are shorter than or equal to the "
+    "line_length.  If longer than the line_length, partial reflow will occur. "
+    "If using long blocks, pay attention to diffs.  Default is True, if False "
+    "long block comments such as ###### will become a single comment (#).",
     "fence_pattern":
     ("Regular expression to match preformat fences in comments default=r'{}'"
      .format(markup.FENCE_PATTERN)),

--- a/cmake_format/format_tests.py
+++ b/cmake_format/format_tests.py
@@ -1206,6 +1206,62 @@ class TestCanonicalFormatting(unittest.TestCase):
           ${CMAKE_CURRENT_SOURCE_DIR}/macOS/cubepp/DemoViewController.h)
     """)
 
+  def test_keep_comment_line_blocks_default(self):
+    # default tests: keep the line blocks
+    self.do_format_test("""
+      ##########################################################################
+      # This comment has a long block before it.                               #
+      ##########################################################################
+    """, """\
+      ##########################################################################
+      # This comment has a long block before it.                               #
+      ##########################################################################
+    """)
+    self.do_format_test("""
+      ##########################################################################
+      # This is a section in the CMakeLists.txt file.                          #
+      ##########################################################################
+      # This stuff below here
+      #     should get re-flowed like
+      # normal comments.  Across multiple
+      #lines and
+      #             beyond.
+    """, """\
+      ##########################################################################
+      # This is a section in the CMakeLists.txt file.                          #
+      ##########################################################################
+      # This stuff below here should get re-flowed like normal comments.  Across
+      # multiple lines and beyond.
+    """)
+
+    # verify the original behavior is as described (they truncate to one #)
+    self.config.keep_comment_line_blocks = False
+    self.do_format_test("""
+      ##########################################################################
+      # This comment has a long block before it.                               #
+      ##########################################################################
+    """, """\
+      #
+      # This comment has a long block before it.                               #
+      #
+    """)
+    self.do_format_test("""
+      ##########################################################################
+      # This is a section in the CMakeLists.txt file.                          #
+      ##########################################################################
+      # This stuff below here
+      #     should get re-flowed like
+      # normal comments.  Across multiple
+      #lines and
+      #             beyond.
+    """, """\
+      #
+      # This is a section in the CMakeLists.txt file.                          #
+      #
+      # This stuff below here should get re-flowed like normal comments.  Across
+      # multiple lines and beyond.
+    """)
+
 
 if __name__ == '__main__':
   format_str = '[%(levelname)-4s] %(filename)s:%(lineno)-3s: %(message)s'

--- a/cmake_format/formatter.py
+++ b/cmake_format/formatter.py
@@ -980,7 +980,7 @@ class FlowControlNode(LayoutNode):
 
 class CommentNode(LayoutNode):
 
-  def _refill_comment_line_blocks(self, config, lines, allocation):
+  def _refill_comment_line_blocks(self, config, lines):
     """
     Keep line comment line blocks equal to the length of the line.
 
@@ -1022,7 +1022,7 @@ class CommentNode(LayoutNode):
 
     allocation = config.linewidth - cursor[1]
     lines = list(format_comment_lines(self.pnode, config, allocation))
-    lines = self._refill_comment_line_blocks(config, lines, allocation)
+    lines = self._refill_comment_line_blocks(config, lines)
     self._colextent = cursor[1] + max(len(line) for line in lines)
 
     increment = (len(lines) - 1, len(lines[-1]))
@@ -1040,7 +1040,7 @@ class CommentNode(LayoutNode):
     else:
       allocation = config.linewidth - self.position[1]
       lines = list(format_comment_lines(self.pnode, config, allocation))
-      lines = self._refill_comment_line_blocks(config, lines, allocation)
+      lines = self._refill_comment_line_blocks(config, lines)
       for idx, line in enumerate(lines):
         ctx.outfile.write_at(self.position + (idx, 0), line)
 


### PR DESCRIPTION
Allows long sequences of #### to be preserved.

Fixes #87.

Name of config variable open to change, see description.  I'm not exactly sure if we should try and be "smart" about if the `####` is longer than `line_length`.  The root of the problem is

```py
inlines.append(token.spelling.strip().lstrip('#'))
```

Doing that is what makes them disappear when building `inlines`, so we need a way to prevent that from happening.  If the `###` sequence is longer than `line_width` it isn't pretty, but I figured I'd open this up for review as a prototype of one possible (and probably easiest?) solution.

Note: I can't use `pylint` with `requirements.txt` version, but lint checks from most recent `pylint` aren't coming from code added here as far as I can tell.  The `make format` also changes a bunch in `cmake_format/parser_tests.py` that I didn't commit.