### PR TITLE
added argument --encoding to allow for non-utf8-encoded CMake files. …

### DIFF
--- a/cmake_format/__main__.py
+++ b/cmake_format/__main__.py
@@ -285,6 +285,9 @@ def setup_argparser(arg_parser):
                                         'html-page', 'html-stub'],
                      default=None)
 
+  arg_parser.add_argument('--encoding', type=str, default="utf-8", 
+                          help='encoding of input/output file')
+
   mutex = arg_parser.add_mutually_exclusive_group()
   mutex.add_argument('-i', '--in-place', action='store_true')
   mutex.add_argument('-o', '--outfile-path', default=None,
@@ -394,7 +397,7 @@ def main():
     if args.in_place:
       ofd, tempfile_path = tempfile.mkstemp(suffix='.txt', prefix='CMakeLists-')
       os.close(ofd)
-      outfile = io.open(tempfile_path, 'w', encoding='utf-8', newline='')
+      outfile = io.open(tempfile_path, 'w', encoding=args.encoding, newline='')
     else:
       if args.outfile_path == '-':
         # NOTE(josh): The behavior or sys.stdout is different in python2 and
@@ -404,17 +407,17 @@ def main():
         # it with byte arrays (assuming it was opened with 'wb'). So we use
         # io.open instead of open in this case
         outfile = io.open(os.dup(sys.stdout.fileno()),
-                          mode='w', encoding='utf-8', newline='')
+                          mode='w', encoding=args.encoding, newline='')
       else:
-        outfile = io.open(args.outfile_path, 'w', encoding='utf-8',
+        outfile = io.open(args.outfile_path, 'w', encoding=args.encoding,
                           newline='')
 
     parse_ok = True
     if infile_path == '-':
       infile = io.open(os.dup(sys.stdin.fileno()),
-                       mode='r', encoding='utf-8', newline='')
+                       mode='r', encoding=args.encoding, newline='')
     else:
-      infile = io.open(infile_path, 'r', encoding='utf-8')
+      infile = io.open(infile_path, 'r', encoding=args.encoding)
 
     try:
       with infile:

--- a/cmake_format/test/test_in.latin1.cmake
+++ b/cmake_format/test/test_in.latin1.cmake
@@ -1,0 +1,2 @@
+# дцья are latin1- Characters which should be tolerated
+# by cmake and kept unchanged

--- a/cmake_format/test/test_out.latin1.cmake
+++ b/cmake_format/test/test_out.latin1.cmake
@@ -1,0 +1,2 @@
+# дцья are latin1- Characters which should be tolerated by cmake and kept
+# unchanged


### PR DESCRIPTION
I require to reformat non-utf8-encoded CMake files. For that purpose I have added a command line option --encoding which defaults to "utf-8" and allows to specifiy the encoding of the input (and output file).