### PR TITLE
allow exact format in per_command:command_case

### DIFF
--- a/cmake_format/format_tests.py
+++ b/cmake_format/format_tests.py
@@ -1152,6 +1152,22 @@ class TestCanonicalFormatting(unittest.TestCase):
       FoO(bar baz)
       """)
 
+    # command_case that is not 'lower' / 'upper' can be used to specify exact
+    # format, rather than 'unchanged'
+    self.do_format_test("""\
+      FeTcHcOnTeNt_DeClArE(bar baz)
+      """, """\
+      fetchcontent_declare(bar baz)
+      """)
+    self.config.per_command["fetchcontent_declare"] = {
+        "command_case": "FetchContent_Declare"
+    }
+    self.do_format_test("""\
+      FeTcHcOnTeNt_DeClArE(bar baz)
+      """, """\
+      FetchContent_Declare(bar baz)
+      """)
+
   def test_quoted_assignment_literal(self):
     self.do_format_test("""\
       target_compile_definitions(foo PUBLIC BAR="Quoted String" BAZ_______________________Z)

--- a/cmake_format/formatter.py
+++ b/cmake_format/formatter.py
@@ -15,6 +15,7 @@ from cmake_format import parser
 
 from cmake_format.lexer import TokenType
 from cmake_format.parser import FlowType, NodeType
+from cmake_format.commands import STRING_TYPES
 
 # A given node consists of arguments, or subtrees. Each of these is an
 # "element". We can either pack all elements "horizontal" or "vertical".
@@ -405,6 +406,9 @@ class ScalarNode(LayoutNode):
       command_case = config.resolve_for_command("command_case", token.spelling)
       if command_case in ("lower", "upper"):
         spelling = getattr(token.spelling, command_case)()
+      elif isinstance(command_case, STRING_TYPES) and \
+          token.spelling.lower() == command_case.lower():
+        spelling = command_case
     elif (self.type in (NodeType.KEYWORD, NodeType.FLAG)
           and config.keyword_case in ("lower", "upper")):
       spelling = getattr(token.spelling, config.keyword_case)()


### PR DESCRIPTION
So this is something I found by accident looking around.  Right now the problem with `unchanged` is that if you accidentally did something like `FEtchContent_Declare` (bad `E` after `F`), that will remain.

Since the machinery for `per_command` with `command_case` is already in place, it's pretty cheap to add this functionality :tada:

It's mostly just `FetchContent_*` and `ExternalProject_*` commands that would need this kind of thing.

If you like it, how / where should I document that this can be done?