### PR TITLE
Fix kwarg/flag passing for non-lowercase fnnames

### DIFF
--- a/cmake_format/commands.py
+++ b/cmake_format/commands.py
@@ -101,10 +101,10 @@ class CommandSpec(dict):
                      .format(key, type(subspec)))
 
   def add(self, name, pargs=None, flags=None, kwargs=None):
-    self[name] = CommandSpec(name, pargs, flags, kwargs)
+    self[name.lower()] = CommandSpec(name, pargs, flags, kwargs)
 
   def add_conditional(self, name):
-    self[name] = make_conditional_spec(name)
+    self[name.lower()] = make_conditional_spec(name)
 
 
 def get_fn_spec():


### PR DESCRIPTION
Prior to this change, all function names would be converted to
lower-case when looking up the cmdspec for that name, resulting in
misses if the function name itself was not all lower case.

I haven't spent much time looking into this, but this fixes my problem and passes the test suite. I can't see any other parts of the code relying on the function name being all lower-case - let me know if this is not the right fix. 