### PR TITLE
Fix handling of --dump-config when there is no existing config file and when the existing config file is empty

### DIFF
--- a/cmake_format/__main__.py
+++ b/cmake_format/__main__.py
@@ -245,6 +245,9 @@ def dump_config(args, config_dict, outfile):
 
   outfmt = args.dump_config
 
+  if config_dict is None:
+    config_dict = {}
+
   for key, value in vars(args).items():
     if (key in configuration.Configuration.get_field_names()
         and value is not None):
@@ -422,6 +425,8 @@ def main():
           and value is not None):
         config_dict[key] = value
 
+    if config_dict is None:
+      config_dict = {}
     cfg = configuration.Configuration(**config_dict)
     if args.in_place:
       ofd, tempfile_path = tempfile.mkstemp(suffix='.txt', prefix='CMakeLists-')


### PR DESCRIPTION
I ran into this problem when trying out the tool on a brand new install:

```
$ cmake-format --dump-config yaml
Traceback (most recent call last):
  File "c:\python\3.7-32\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\python\3.7-32\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Python\3.7-32\Scripts\cmake-format.exe\__main__.py", line 9, in <module>
  File "c:\python\3.7-32\lib\site-packages\cmake_format\__main__.py", line 389, in main
    dump_config(args, config_dict, sys.stdout)
  File "c:\python\3.7-32\lib\site-packages\cmake_format\__main__.py", line 253, in dump_config
    cfg = configuration.Configuration(**config_dict)
TypeError: type object argument after ** must be a mapping, not NoneType
```

With the fix:

```
$ cmake-format --dump-config yaml
line_width: 80
tab_size: 2
max_subargs_per_line: 3
separate_ctrl_name_with_space: false
separate_fn_name_with_space: false
dangle_parens: false
[...]
```