### PR TITLE
Avoid writing outfile unnecessarily for better compatibility with other tooling like pre-commit hooks

### DIFF
--- a/cmake_format/__main__.py
+++ b/cmake_format/__main__.py
@@ -432,7 +432,8 @@ def main():
     try:
       with infile:
         infile_original_content = infile.read()
-        process_file(cfg, io.StringIO(infile_original_content), outfile_content, args.dump)
+        process_file(cfg, io.StringIO(infile_original_content), outfile_content,
+                     args.dump)
     except:
       sys.stderr.write('While processing {}\n'.format(infile_path))
       raise
@@ -456,8 +457,8 @@ def main():
           outfile = io.open(os.dup(sys.stdout.fileno()),
                             mode='w', encoding=cfg.output_encoding, newline='')
         else:
-          outfile = io.open(args.outfile_path, 'w', encoding=cfg.output_encoding,
-                            newline='')
+          outfile = io.open(args.outfile_path, 'w',
+                            encoding=cfg.output_encoding, newline='')
 
         outfile.write(outfile_content.getvalue())
 

--- a/cmake_format/__main__.py
+++ b/cmake_format/__main__.py
@@ -20,7 +20,6 @@ import io
 import json
 import logging
 import os
-import shutil
 import sys
 
 import cmake_format
@@ -424,7 +423,6 @@ def main():
     cfg = configuration.Configuration(**config_dict)
     outfile_content = io.StringIO()
 
-    parse_ok = True
     if infile_path == '-':
       infile = io.open(os.dup(sys.stdin.fileno()),
                        mode='r', encoding=cfg.input_encoding, newline='')
@@ -434,10 +432,8 @@ def main():
     try:
       with infile:
         infile_original_content = infile.read()
-        infile.seek(0)
-        process_file(cfg, infile, outfile_content, args.dump)
+        process_file(cfg, io.StringIO(infile_original_content), outfile_content, args.dump)
     except:
-      parse_ok = False
       sys.stderr.write('While processing {}\n'.format(infile_path))
       raise
     finally:


### PR DESCRIPTION
I use [pre-commit hooks](https://github.com/pre-commit/pre-commit) in my projects to run `clang-format -i` and some other commands automatically, and I'd like to incorporate `cmake-format -i` as well. However, cmake-format always overwrites the outfile, even if it's identical to the original, and that write is interpreted by the hook as a sign that there was a problem that had to be fixed, which means the hook fails and blocks the commit. This PR ensures that an in-place write is only performed if there was a change:

* Move the outfile opening code to the end of `main()`, once we know if there have been changes.
* Remove the on-disk temp file, since `process_file()` and such are now working with a dummy `StringIO`.