### PR TITLE
Allow multiple config files

### DIFF
--- a/cmake_format/doc/README.rst
+++ b/cmake_format/doc/README.rst
@@ -40,7 +40,7 @@ Usage
     usage:
     cmake-format [-h]
                  [--dump-config {yaml,json,python} | -i | -o OUTFILE_PATH]
-                 [-c CONFIG_FILE]
+                 [-c CONFIG_FILE] [CONFIG_FILE ...]
                  infilepath [infilepath ...]
 
     Parse cmake listfiles and format them nicely.
@@ -69,8 +69,8 @@ Usage
       -i, --in-place
       -o OUTFILE_PATH, --outfile-path OUTFILE_PATH
                             Where to write the formatted file. Default is stdout.
-      -c CONFIG_FILE, --config-file CONFIG_FILE
-                            path to configuration file
+      -c CONFIG_FILE [CONFIG_FILE ...], --config-file CONFIG_FILE [CONFIG_FILE ...], --config-files CONFIG_FILE [CONFIG_FILE ...]
+                            path to configuration file(s)
 
     Formatter Configuration:
       Override configfile options affecting general formatting

--- a/cmake_format/invocation_tests.py
+++ b/cmake_format/invocation_tests.py
@@ -223,6 +223,32 @@ class TestInvocations(unittest.TestCase):
     if delta_lines:
       raise AssertionError('\n'.join(delta_lines[2:]))
 
+  def test_multiple_config_invocation(self):
+    """
+    Test invocation with multiple config files specified
+    """
+    thisdir = os.path.realpath(os.path.dirname(__file__))
+    configpath = os.path.join(thisdir, 'test')
+    infile_path = os.path.join(thisdir, 'test', 'test_in.cmake')
+    expectfile_path = os.path.join(thisdir, 'test', 'test_out.cmake')
+
+    subprocess.check_call([sys.executable, '-Bm', 'cmake_format', '-c',
+                           os.path.join(configpath, 'cmake-format-split1.py'),
+                           os.path.join(configpath, 'cmake-format-split2.py'),
+                           '-o', os.path.join(self.tempdir, 'test_out.cmake'),
+                           infile_path], cwd=self.tempdir, env=self.env)
+
+    with io.open(os.path.join(self.tempdir, 'test_out.cmake'), 'r',
+                 encoding='utf8') as infile:
+      actual_text = infile.read()
+    with io.open(expectfile_path, 'r', encoding='utf8') as infile:
+      expected_text = infile.read()
+
+    delta_lines = list(difflib.unified_diff(expected_text.split('\n'),
+                                            actual_text.split('\n')))
+    if delta_lines:
+      raise AssertionError('\n'.join(delta_lines[2:]))
+
   def test_auto_lineendings(self):
     """
     Verify that windows line-endings are detected and preserved on input.

--- a/cmake_format/test/cmake-format-split1.py
+++ b/cmake_format/test/cmake-format-split1.py
@@ -1,0 +1,22 @@
+# How wide to allow formatted cmake files
+line_width = 80
+
+# How many spaces to tab for indent (overridden by cmake-format-split2.py)
+tab_size = 10
+
+# If arglists are longer than this, break them always.
+max_subargs_per_line = 3
+
+# If true, separate control flow names from the parentheses with a space
+separate_ctrl_name_with_space = False
+
+# If true, separate function names from the parenthesis with a space
+separate_fn_name_with_space = False
+
+# Additional FLAGS and KWARGS for custom commands
+# (extended by cmake-format-split2.py)
+additional_commands = {
+  "foo": {
+    "flags": ["BAR", "BAZ"],
+  }
+}

--- a/cmake_format/test/cmake-format-split2.py
+++ b/cmake_format/test/cmake-format-split2.py
@@ -1,0 +1,13 @@
+# How many spaces to tab for indent
+tab_size = 2
+
+# Additional FLAGS and KWARGS for custom commands
+additional_commands = {
+  "foo": {
+    "kwargs": {
+      "HEADERS": '*',
+      "SOURCES": '*',
+      "DEPENDS": '*',
+    }
+  }
+}


### PR DESCRIPTION
Extend '--config-file' command line option to support multiple config files. The configuration parameters get merged recursively.

This is useful to ship a definition of 'additional_commands' with a library of CMake modules while still allowing the user to provide his own project specific config file.