### PR TITLE
Fix ordering of cwd location to fix nested configuration files

### DIFF
--- a/cmake_format/vscode_extension/src/extension.ts
+++ b/cmake_format/vscode_extension/src/extension.ts
@@ -27,16 +27,16 @@ export function activate(context: vscode.ExtensionContext) {
                 };
 
                 var cwd = config.get("cwd");
+                if (cwd == null && document.uri.fsPath != null) {
+                    cwd = path.dirname(document.uri.fsPath)
+                    console.log("No cwd configured, falling back to file location: " + cwd);
+                }
                 if (cwd == null) {
                     var folder = vscode.workspace.getWorkspaceFolder(document.uri);
                     if (folder != null) {
                         cwd = folder.uri.fsPath;
-                        console.log("No cwd configured, using workspace path: " + cwd);
+                        console.log("No cwd configured and no file path, falling back to workspace path: " + cwd);
                     }
-                }
-                if (cwd == null && document.uri.fsPath != null) {
-                    cwd = path.dirname(document.uri.fsPath)
-                    console.log("No cwd configured, no workspace path, using: " + cwd);
                 }
                 if (cwd != null && fs.statSync(cwd).isDirectory()) {
                     opts["cwd"] = cwd;


### PR DESCRIPTION
Currently, the vscode extension uses the wrong cmake-format configuration file when formatting files when they are nested.
For example, given the following directory structure

```
.vscode/
    settings.json
subfolder/
    cmake-format.py
    CMakeLists.txt
cmake-format.py
```

When formatting `subfolder/CMakeLists.txt` it uses the root level project `cmake-format.py` file rather than the correct one (`subfolder/cmake-format.py`) that is located next to it.
This is because the code was defaulting to using the project directory as the cwd over the path of the file itself.
This PR rearranges the if statements so that it finds the correct format file.