### PR TITLE
cmakeFormat.args is an array of items of type string

### DIFF
--- a/cmake_format/vscode_extension/package.json
+++ b/cmake_format/vscode_extension/package.json
@@ -61,7 +61,10 @@
                     "description": "Full path cmake-format entry point script or binary"
                 },
                 "cmakeFormat.args": {
-                    "type": "array[string]",
+                    "type": "array",
+                    "items": {
+                        "type" : "string"
+                    },
                     "default": [],
                     "description": "Additional arguments to pass to cmake-format. Specify, e.g. --config-file here."
                 }


### PR DESCRIPTION
Following the json schema, https://json-schema.org/understanding-json-schema/reference/array.html#array, an array of specific type should should declare the type in the keyword "items".

Fixes #129 