### PR TITLE
README.rst: fix two typos

### DIFF
--- a/cmake_format/configuration.py
+++ b/cmake_format/configuration.py
@@ -339,7 +339,7 @@ VARDOCS = {
         " level, `child`: align to the column of the arguments"),
     "max_prefix_chars": (
         "If the statement spelling length (including space and parenthesis"
-        " is larger than the tab width by more than this amoung, then"
+        " is larger than the tab width by more than this amount, then"
         " force reject un-nested layouts."),
     "max_lines_hwrap": (
         "If a candidate layout is wrapped horizontally but it exceeds this"

--- a/cmake_format/doc/README.rst
+++ b/cmake_format/doc/README.rst
@@ -481,7 +481,7 @@ long-form and a short-form for each. The acceptable formats are:
 
 In order to annotate a positional argument list as sortable, the acceptable
 tags are: ``sortable`` or ``sort``. For the commands listed above where
-the positinal argument lists are inherently sortable, you can locally disable
+the positional argument lists are inherently sortable, you can locally disable
 sorting by annotating them with ``unsortable`` or ``unsort``. For example::
 
     add_library(foobar STATIC
@@ -541,7 +541,7 @@ fields:
   only positionals, then it can be simply the ``pargs`` specification (as in
   the example above).
 
-For the example specification above, the custom command would look somehing
+For the example specification above, the custom command would look something
 like this:
 
 .. code::

--- a/cmake_format/doc/README.rst
+++ b/cmake_format/doc/README.rst
@@ -106,7 +106,7 @@ Usage
       --max-prefix-chars MAX_PREFIX_CHARS
                             If the statement spelling length (including space and
                             parenthesis is larger than the tab width by more than
-                            this amoung, then force reject un-nested layouts.
+                            this amount, then force reject un-nested layouts.
       --max-lines-hwrap MAX_LINES_HWRAP
                             If a candidate layout is wrapped horizontally but it
                             exceeds this many lines, then reject the layout.
@@ -227,7 +227,7 @@ pleasant way.
     min_prefix_chars = 4
 
     # If the statement spelling length (including space and parenthesis is larger
-    # than the tab width by more than this amoung, then force reject un-nested
+    # than the tab width by more than this amount, then force reject un-nested
     # layouts.
     max_prefix_chars = 10
 

--- a/cmake_format/doc/README.rst
+++ b/cmake_format/doc/README.rst
@@ -105,7 +105,7 @@ Usage
       --min-prefix-chars MIN_PREFIX_CHARS
       --max-prefix-chars MAX_PREFIX_CHARS
                             If the statement spelling length (including space and
-                            parenthesis is larger than the tab width by more than
+                            parenthesis) is larger than the tab width by more than
                             this amount, then force reject un-nested layouts.
       --max-lines-hwrap MAX_LINES_HWRAP
                             If a candidate layout is wrapped horizontally but it
@@ -574,7 +574,7 @@ You can also join the ``#cmake-format`` channel on our `discord server`_.
 Developers
 ----------
 
-If you want to hack on ``cmake-format``, please see the `documenation`__ for
+If you want to hack on ``cmake-format``, please see the `documentation`__ for
 contribution rules and guidelines.
 
 .. __: https://cmake-format.rtfd.io/contributing.html

--- a/cmake_format/doc/features.rst
+++ b/cmake_format/doc/features.rst
@@ -200,7 +200,7 @@ fields:
   only positionals, then it can be simply the ``pargs`` specification (as in
   the example above).
 
-For the example specification above, the custom command would look somehing
+For the example specification above, the custom command would look something
 like this:
 
 .. code::

--- a/cmake_format/doc/usage.rst
+++ b/cmake_format/doc/usage.rst
@@ -61,7 +61,7 @@ pleasant way.
     min_prefix_chars = 4
 
     # If the statement spelling length (including space and parenthesis is larger
-    # than the tab width by more than this amoung, then force reject un-nested
+    # than the tab width by more than this amount, then force reject un-nested
     # layouts.
     max_prefix_chars = 10
 
@@ -252,7 +252,7 @@ Usage
       --max-prefix-chars MAX_PREFIX_CHARS
                             If the statement spelling length (including space and
                             parenthesis is larger than the tab width by more than
-                            this amoung, then force reject un-nested layouts.
+                            this amount, then force reject un-nested layouts.
       --max-lines-hwrap MAX_LINES_HWRAP
                             If a candidate layout is wrapped horizontally but it
                             exceeds this many lines, then reject the layout.


### PR DESCRIPTION
Hello,
thank you very much for cmake_format. 
We plan to use it in our project, so I started with reading the documentaton. 
As I found two typos here is my PR.

Best regards,

Philipp