### PR TITLE
Fixed typos and bugs in vscode extension

### DIFF
--- a/cmake_format/contrib/signature_db.json
+++ b/cmake_format/contrib/signature_db.json
@@ -14,5 +14,21 @@
       "ExK+IzcU5OhFUWan7/sEtJBCH5tmUQ==",
       "=MohZ"
     ]
+  },
+  {
+    "template": "individual",
+    "version": "1.0",
+    "name": "Andre Brisco",
+    "email": "andre.brisco@gmail.com",
+    "signature": [
+      "iQEzBAABCAAdFiEEWr16n8+Ng31/16dIiueGFd/AzYkFAl6On+AACgkQiueGFd/A",
+      "zYkFvQf8CJts2KdG+NrFf0uoFT7mFWW8QBpHDWWke3Wmw9ATs0xMCy/QFXtbW0hG",
+      "DRTPCoZ0Wy2u0jxlNeaIa5cAzgM8nNjotgooSrUQxjKePtnrkiWSyltV7oaAHJ9K",
+      "RIpvx4Xiva2ibac7kWUbzScIhieQw3s1o2whtGyyLa/AkUZMCQCItsZnqDHhaRKk",
+      "+fZ6JrvaS7pjSuz2wpgZnBhzqbEwFcPVxgJ8SmgWsCyID6WpXRtTEvx2Z0Djz5xr",
+      "rYPxO7oXIZ7gMo0vUrR5YM0qT2icEg5ZnC2QIgSUF9cW7NFyIV/BDxdi0EYFIaoT",
+      "46OOj1B85tUs1+f6wCuX4SyIVww5aA==",
+      "=4ykw"
+    ]
   }
 ]

--- a/cmake_format/vscode_extension/src/extension.ts
+++ b/cmake_format/vscode_extension/src/extension.ts
@@ -62,12 +62,12 @@ export function activate(context: vscode.ExtensionContext) {
       }
       var cenv: any = config.get("env", {});
       if (cenv !== null) {
-        var delim = path.delimeter;
+        var delim = path.delimiter;
         for (var [key, value] of Object.entries(cenv)) {
           if (key.endsWith("PATH")) {
             var items = cenv[key].split(delim);
             if (key in env) {
-              items = items.concat(env[key].spit(delim));
+              items = items.concat(env[key].split(delim));
             }
             env[key] = items.join(delim);
           } else {


### PR DESCRIPTION
At first I just wanted to fix a typo but I found some other issues. I was having issues setting a path and couldn't get anything to run. It looks like the extension was incompatible with the current release of `cmake-format`? Anyway, this fixes it for me