### PR TITLE
Changes to use as a lib

### DIFF
--- a/cmake_format/__init__.py
+++ b/cmake_format/__init__.py
@@ -2,5 +2,7 @@
 Parse cmake listfiles and format them nicely
 """
 from __future__ import unicode_literals
+from .__main__ import process_file
+from .configuration import Configuration
 
 VERSION = '0.6.10.dev3'


### PR DESCRIPTION
I had some Python code that was generating CMake scripts using Jinja2, and I wanted to run cmake-format on it automatically. The location of the process_file function in `__main__` made it inaccessible to a normal consuming python app. This change makes it accessible, so that it can be automated.