### PR TITLE
cmake-lint: add C0328: file(GLOB | GLOB_RECURSE) detection

### DIFF
--- a/cmake_format/configuration.py
+++ b/cmake_format/configuration.py
@@ -175,6 +175,8 @@ class LinterConfig(ConfigObject):
   max_localvars = FieldDescriptor(15,)
   max_statements = FieldDescriptor(50,)
 
+  forbid_glob = FieldDescriptor(True, "Forbid file(GLOB) command")
+
 
 ADDITIONAL_COMMANDS_DEMO = {
     'foo': {

--- a/cmake_format/contrib/signature_db.json
+++ b/cmake_format/contrib/signature_db.json
@@ -30,5 +30,26 @@
       "46OOj1B85tUs1+f6wCuX4SyIVww5aA==",
       "=4ykw"
     ]
+  },
+  {
+    "template": "individual",
+    "version": "1.0",
+    "name": "Vladislav Ivanov",
+    "email": "vladislav.ivanov@esrlabs.com",
+    "signature": [
+      "iQIzBAABCAAdFiEE2+v+J06UtYvoYPbs/QnhsRaYLyMFAl8LQOIACgkQ/QnhsRaY",
+      "LyOvoQ/9FeaiIv5SY1fDeB6K3J6IZg673ZHcR5lnHKaMlFL7PNH5nlaYlOYybJmA",
+      "1Z24aoD6QrX5qvynJ/vQBsAJTH9Bcb32sWon2EhBpSMLGRbM2hLHCgWDOZ1rXWbj",
+      "0cIT7YPpsJA7vRWAdCpllwyKiur9Vhnox6pAXwV2HDc+NBTjZFSQ0Y+Q8/1QYqHm",
+      "0xMxoQVCYTsZ+pi2jxBnHDz5GRzB+E3GnmHFEZb60vC+SEx77pLW+9X05X72bK+2",
+      "YhELjL6pwIdPJYIz5bGE0dadW/W5gf5lxZ+6HDPxdVCsg4pJ5kUVJPZyXK6Zt7NV",
+      "V0fkUgRiAFiqQrGHu0IxuysPEdZnEdEMQQLUzc57iVsR8afgHIHDsi6DKFwE9kZf",
+      "meu0bhJT5WGIskdbWGIKdEdwnkr7CVK1A/VHoWuIXKs/zw7v1nlmkPTfQXBidL4l",
+      "/R/wewvF5jkXkEe3XeDThgol2neDYwkKMADxyRpuwfh8zgqpPIBjcZlQy43oCDzJ",
+      "pWejB7EPgLkgUrlV2ROkdIyrHkmysYl9JyJYVX+am3iWz5qdtMHOLhbC5AiS+q2g",
+      "aHriSVH6yrV/zEum4X/IGmtNzcmNbLzPAA22RBQ9wNw9XaeRlC0DbeZUqezTz76u",
+      "adPqt3DV8JY+NyMQRxzsyYul+AiJU098FEunFc1A/8OhAIKEVSs=",
+      "=TRB8"
+    ]
   }
 ]

--- a/cmake_lint/lintdb.py
+++ b/cmake_lint/lintdb.py
@@ -167,6 +167,15 @@ While cmake itself does not enforce a particular line ending, it is good
 practice for a project to be consist with their line endings.
 """
 }), (
+"C0328", "Usage of file(GLOB ...)", {
+"description": """\
+Appears when file(GLOB ...) command is used.
+""",
+"explain": """\
+GLOB is I/O heavy and introduces additional non-determinism in CMake configuration
+process. It is advised to list all CMake input files explicitly.
+"""
+}), (
 "E0011", "Unrecognized file option {:s}", {
 "description": """\
 Used when an unrecognized pragma is encountered.

--- a/cmake_lint/test/expect_lint.cmake
+++ b/cmake_lint/test/expect_lint.cmake
@@ -53,6 +53,10 @@ file(${form} foo.py)
 
 file(TOUCHE foo.py)
 
+file(GLOB foo LIST_DIRECTORIES false *)
+
+file(GLOB_RECURSE foo CONFIGURE_DEPENDS *.cpp)
+
 break()
 
 continue()

--- a/cmake_lint/test/lint_tests.cmake
+++ b/cmake_lint/test/lint_tests.cmake
@@ -83,6 +83,14 @@ file(${form} foo.py)
 # expect: E1126
 file(TOUCHE foo.py)
 
+# test: file-forbid-glob-1
+# expect: C0328
+file(GLOB foo LIST_DIRECTORIES false *)
+
+# test: file-forbid-glob-2
+# expect: C0328
+file(GLOB_RECURSE foo CONFIGURE_DEPENDS *.cpp)
+
 # test: break-not-in-loop
 # expect: E0103
 break()


### PR DESCRIPTION
From CMake documentation:

>Note: We do not recommend using GLOB to collect a list of source files from your source tree. If no CMakeLists.txt file changes when a source is added or removed then the generated build system cannot know when to ask CMake to regenerate. The CONFIGURE_DEPENDS flag may not work reliably on all generators, or if a new generator is added in the future that cannot support it, projects using it will be stuck. Even if CONFIGURE_DEPENDS works reliably, there is still a cost to perform the check on every rebuild.
