### PR TITLE
Add always_dangle_first_parg

### DIFF
--- a/cmakelang/command_tests/misc_tests.cmake
+++ b/cmakelang/command_tests/misc_tests.cmake
@@ -347,6 +347,17 @@ cmake_parse_arguments(
 # TODO(josh): This todo should not be joined with the previous line.
 # NOTE(josh): Also this should not be joined with the todo.
 
+# test: always_dangle_first_parg_01
+#[=[
+always_dangle_first_parg = ['target_link_libraries']
+]=]
+#[==[
+target_link_libraries(nonkwarg_a PUBLIC liba libb libc PRIVATE libd libe libf)
+]==]
+target_link_libraries(nonkwarg_a
+  PUBLIC liba libb libc
+  PRIVATE libd libe libf)
+
 # test: always_wrap_01
 #[=[
 max_subgroups_hwrap = 100

--- a/cmakelang/command_tests/misc_tests.py
+++ b/cmakelang/command_tests/misc_tests.py
@@ -15,7 +15,7 @@ class TestMiscFormatting(TestBase):
   """
   Ensure that various inputs format the way we want them to
   """
-  kExpectNumSidecarTests = 86
+  kExpectNumSidecarTests = 87
 
   def test_config_hashruler_minlength(self):
 

--- a/cmakelang/configuration.py
+++ b/cmakelang/configuration.py
@@ -309,6 +309,11 @@ class FormattingConfig(ConfigObject):
       ['lower', 'upper', 'unchanged']
   )
 
+  always_dangle_first_parg = FieldDescriptor(
+      [],
+      "A list of command names which should always dangle first argument"
+  )
+
   always_wrap = FieldDescriptor(
       [],
       "A list of command names which should always be wrapped"


### PR DESCRIPTION
This commit adds a new configuration in format so that the first parg
can be dangled at the statement line. This is a common style which is
also used in CMakeLists.txt of cmake itself.