### PR TITLE
fix: linter accepts all forms of foreach range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ vscode_extension/out
 
 # Temp/backup files
 *~
+
+# PyCharm
+/.idea

--- a/cmakelang/contrib/signature_db.json
+++ b/cmakelang/contrib/signature_db.json
@@ -30,5 +30,24 @@
       "46OOj1B85tUs1+f6wCuX4SyIVww5aA==",
       "=4ykw"
     ]
+  },
+  {
+    "template": "individual",
+    "version": "1.0",
+    "name": "mtepfer",
+    "email": "mtepfer1@gmail.com",
+    "signature": [
+      "iQGzBAABCgAdFiEE/e9a5rpDT6fKx54O9liG9QN8TdAFAmCm8ZcACgkQ9liG9QN8",
+      "TdDh8AwA1MREvU9dweCAliVDPxgdM+BlUecJ94D4QJa30Ri0ekN2siPc7ge/NDW6",
+      "i3YNkbe2ZZlNU/l8TOpa52kko6pBB/Jkof178X9TgNHKkJBbmm47U0LmztWLw76J",
+      "iCtgKokA8ZHST7ZMgp9YewjeHA6Tx3624GXNVYikjOPnpLs77J7UuRhtz6jBDDi/",
+      "P4JMqUhxQvzMQXz6pnca7du3B+mCFXKR4hGRM+miQANI7VQCIGe0ljc5xEmWOTDY",
+      "3uTRUJupNJ9Ib1sJOw6tBNzykGbZcoNKLLDYTXHavd9iqLfhMa6hE4521mXuppzi",
+      "eVk2R14U2ppUz5kTyHli1HHUeqrbk4x3Da7PXQXnPOtnBKsOBGBTffj404GNWUcM",
+      "u9UDj7Pa2NPV9AQIGdlqJPviuTA2gmVVkdN4ArsN31o/RGtuFtuwYK79PBrirLI4",
+      "IxRSNupJXIaEnMiRD5pEyUD4qu1pa/bQxxVjZ0KxUWiHNk3rYaHp0YzYO1GS5s8q",
+      "DMe6XbrS",
+      "=XNI6"
+    ]
   }
 ]

--- a/cmakelang/parse/argument_nodes.py
+++ b/cmakelang/parse/argument_nodes.py
@@ -342,6 +342,7 @@ class PositionalGroupNode(TreeNode):
     * "?": zero or one
     * "*": zero or more
     * "+": one or more
+    * "min-max": where min is the minimum pargs count and max is the maximum pargs count
     """
 
     tree = cls(sortable=spec.sortable, tags=spec.tags)

--- a/cmakelang/parse/funs/foreach.py
+++ b/cmakelang/parse/funs/foreach.py
@@ -64,7 +64,7 @@ def parse_foreach_range(ctx, tokens, breakstack):
   return StandardArgTree.parse(
       ctx, tokens,
       npargs=1,
-      kwargs={"RANGE": PositionalParser(3)},
+      kwargs={"RANGE": PositionalParser("1-3")},
       flags=[],
       breakstack=breakstack
   )

--- a/cmakelang/parse/tests.py
+++ b/cmakelang/parse/tests.py
@@ -317,6 +317,121 @@ class TestCanonicalParse(unittest.TestCase):
           ]),
       ])
 
+  def test_foreach_range_one_arg(self):
+    self.do_type_test("""\
+      foreach(loopvar RANGE 3)
+      endforeach()
+    """, [
+        (NodeType.BODY, [
+            (NodeType.WHITESPACE, []),
+            (NodeType.FLOW_CONTROL, [
+                (NodeType.STATEMENT, [
+                    (NodeType.FUNNAME, []),
+                    (NodeType.LPAREN, []),
+                    (NodeType.ARGGROUP, [
+                        (NodeType.PARGGROUP, [
+                            (NodeType.ARGUMENT, []),
+                        ]),
+                        (NodeType.KWARGGROUP, [
+                            (NodeType.KEYWORD, []),
+                            (NodeType.PARGGROUP, [
+                                (NodeType.ARGUMENT, []),
+                            ]),
+                        ]),
+                    ]),
+                    (NodeType.RPAREN, []),
+                ]),
+                (NodeType.BODY, [
+                    (NodeType.WHITESPACE, []),
+                ]),
+                (NodeType.STATEMENT, [
+                    (NodeType.FUNNAME, []),
+                    (NodeType.LPAREN, []),
+                    (NodeType.ARGGROUP, []),
+                    (NodeType.RPAREN, []),
+                ]),
+            ]),
+            (NodeType.WHITESPACE, []),
+        ])
+    ])
+
+  def test_foreach_range_two_arg(self):
+    self.do_type_test("""\
+      foreach(loopvar RANGE 1 3)
+      endforeach()
+    """, [
+        (NodeType.BODY, [
+            (NodeType.WHITESPACE, []),
+            (NodeType.FLOW_CONTROL, [
+                (NodeType.STATEMENT, [
+                    (NodeType.FUNNAME, []),
+                    (NodeType.LPAREN, []),
+                    (NodeType.ARGGROUP, [
+                        (NodeType.PARGGROUP, [
+                            (NodeType.ARGUMENT, []),
+                        ]),
+                        (NodeType.KWARGGROUP, [
+                            (NodeType.KEYWORD, []),
+                            (NodeType.PARGGROUP, [
+                                (NodeType.ARGUMENT, []),
+                                (NodeType.ARGUMENT, []),
+                            ]),
+                        ]),
+                    ]),
+                    (NodeType.RPAREN, []),
+                ]),
+                (NodeType.BODY, [
+                    (NodeType.WHITESPACE, []),
+                ]),
+                (NodeType.STATEMENT, [
+                    (NodeType.FUNNAME, []),
+                    (NodeType.LPAREN, []),
+                    (NodeType.ARGGROUP, []),
+                    (NodeType.RPAREN, []),
+                ]),
+            ]),
+            (NodeType.WHITESPACE, []),
+        ])
+    ])
+
+  def test_foreach_range_three_arg(self):
+    self.do_type_test("""\
+      foreach(loopvar RANGE 1 3 1)
+      endforeach()
+    """, [(NodeType.BODY, [
+        (NodeType.WHITESPACE, []),
+        (NodeType.FLOW_CONTROL, [
+            (NodeType.STATEMENT, [
+                (NodeType.FUNNAME, []),
+                (NodeType.LPAREN, []),
+                (NodeType.ARGGROUP, [
+                    (NodeType.PARGGROUP, [
+                        (NodeType.ARGUMENT, []),
+                    ]),
+                    (NodeType.KWARGGROUP, [
+                        (NodeType.KEYWORD, []),
+                        (NodeType.PARGGROUP, [
+                            (NodeType.ARGUMENT, []),
+                            (NodeType.ARGUMENT, []),
+                            (NodeType.ARGUMENT, []),
+                        ]),
+                    ]),
+                ]),
+                (NodeType.RPAREN, []),
+            ]),
+            (NodeType.BODY, [
+                (NodeType.WHITESPACE, []),
+            ]),
+            (NodeType.STATEMENT, [
+                (NodeType.FUNNAME, []),
+                (NodeType.LPAREN, []),
+                (NodeType.ARGGROUP, []),
+                (NodeType.RPAREN, []),
+            ]),
+        ]),
+        (NodeType.WHITESPACE, []),
+    ])])
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/cmakelang/parse/util.py
+++ b/cmakelang/parse/util.py
@@ -209,6 +209,15 @@ def pargs_are_full(npargs, nconsumed):
       _ = int(npargs[:-1])
     except ValueError:
       raise ValueError("Unexepected npargs {}".format(npargs))
+
+  dash_pos = npargs.find("-")
+  if dash_pos != -1:
+    try:
+      max = int(npargs[dash_pos+1:])
+      return nconsumed >= max
+    except ValueError:
+      raise ValueError("Unexepected npargs {}".format(npargs))
+
   return False
 
 
@@ -238,6 +247,13 @@ def get_min_npargs(npargs):
   if npargs.endswith("+"):
     try:
       return int(npargs[:-1])
+    except ValueError:
+      pass
+
+  dash_pos = npargs.find("-")
+  if dash_pos != -1:
+    try:
+      return int(npargs[0:dash_pos])
     except ValueError:
       pass
 


### PR DESCRIPTION
* updated positional parser to accespt range specification
* updated foreach range keyword to use new range spec
* add PyCharm files to .gitignore
* mtepfer sign contributor agreement

closes #256