### PR TITLE
Compatibility with `argparse-manpage`

### DIFF
--- a/cmakelang/annotate.py
+++ b/cmakelang/annotate.py
@@ -107,17 +107,26 @@ def setup_argparser(arg_parser):
   arg_parser.add_argument('infilepaths', nargs='*')
 
 
+def get_argparser():
+  argparser = argparse.ArgumentParser(
+      prog='cmake-annotate',
+      description=__doc__,
+      formatter_class=argparse.RawDescriptionHelpFormatter,
+      usage=USAGE_STRING)
+
+  setattr(argparser, 'man_short_description', __doc__.strip().splitlines()[0])
+
+  setup_argparser(argparser)
+  return argparser
+
+
 def main():
   """Parse arguments, open files, start work."""
 
   # set up main logger, which logs everything. We'll leave this one logging
   # to the console
   logging.basicConfig(level=logging.INFO)
-  arg_parser = argparse.ArgumentParser(
-      description=__doc__,
-      formatter_class=argparse.RawDescriptionHelpFormatter,
-      usage=USAGE_STRING)
-  setup_argparser(arg_parser)
+  arg_parser = get_argparser()
   args = arg_parser.parse_args()
 
   assert (len(args.infilepaths) == 1

--- a/cmakelang/contrib/signature_db.json
+++ b/cmakelang/contrib/signature_db.json
@@ -30,5 +30,26 @@
       "46OOj1B85tUs1+f6wCuX4SyIVww5aA==",
       "=4ykw"
     ]
+  },
+  {
+    "template": "individual",
+    "version": "1.0",
+    "name": "Ian Campbell",
+    "email": "ijc@debian.org",
+    "signature": [
+      "iQIzBAABCAAdFiEE7fn8DiT6MgcCyDswKi4ln2laRsYFAmO6oWoACgkQKi4ln2la",
+      "RsZGOw//Qhm+ZscRad8D23eqs0fbWYFSOIZGzlPWnu9RiRcmmSOvuPi2AwZM9pUV",
+      "aTi8Fuh3Y8wx1OjWw7Px8TfWDwLvV52cCTt7G7RVIDxUhGyPuEttYgwK2ADc3bYz",
+      "Qe3gns/CeCWFQCbb1pQzd5pTc2Ocj0LvEpZOt16Uqi+vDYduhstZ38NneqRzC8S6",
+      "54UQXSKfEmm8SbsxMBxQIVErxE2Op8z2eSjy1yZfwVdiJifLDzJ6fDQpQt3tKZxC",
+      "JYxbHLeii8H6MIuV/XR2Cr7cyMkOCUYUgbY4drqMA3bbUdrEASAbAazMNCMAmouh",
+      "FBP3NWfv0hGae7azfBetPIpibo5xXc4Hg3EkxHK8UeZ9swZtLXZhSwwglDFr13CE",
+      "57Lq/Kjhd/2zr6LEtUFd1HPx66qFDdCnrXHckoWqHr4fMEiBNXYV3JoPsBs/n2ae",
+      "VD03NxxMPzgoTqmqikZBkURnFT0aogzEQjffYIde+xeyLFKWTg9ibRaugizOsPV/",
+      "Q0D9JQ0qXkn1JhJWCmE2r0TDY2Z06ZpB+dnBhNfepgXb/YBmCYDk0lhoocjqPt6Q",
+      "BG1MRlycaZkYWb01TPbCvV1n1Ecp/UzQlG9tzaiUDtL5kGUixKT1hBje6grxw4+C",
+      "jW75xhPbMkGTjEWg9ugrwmj0gkGBjx5cC8w7s4UBPCv5XQQAjXQ=",
+      "=AXfC"
+    ]
   }
 ]

--- a/cmakelang/format/__main__.py
+++ b/cmakelang/format/__main__.py
@@ -566,15 +566,22 @@ def onefile_main(infile_path, args, argparse_dict):
     shutil.move(tempfile_path, infile_path)
 
 
-def inner_main():
-  """Parse arguments, open files, start work."""
-
+def get_argparser():
   arg_parser = argparse.ArgumentParser(
+      prog='cmake-format',
       description=__doc__,
       formatter_class=argparse.RawDescriptionHelpFormatter,
       usage=USAGE_STRING)
 
+  setattr(arg_parser, 'man_short_description', __doc__.strip().splitlines()[0])
+
   setup_argparser(arg_parser)
+  return arg_parser
+
+def inner_main():
+  """Parse arguments, open files, start work."""
+
+  arg_parser = get_argparser()
   try:
     import argcomplete
     argcomplete.autocomplete(arg_parser)

--- a/cmakelang/genparsers.py
+++ b/cmakelang/genparsers.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Parse cmake listfiles, find function and macro declarations, and generate
-parsers for them.
+Parse cmake listfiles, find function and macro declarations, and generate parsers for them.
 """
 from __future__ import print_function, unicode_literals
 
@@ -214,6 +213,19 @@ def setup_argparse(argparser):
   argparser.add_argument('infilepaths', nargs='*')
 
 
+def get_argparser():
+  argparser = argparse.ArgumentParser(
+      prog='cmake-genparsers',
+      description=__doc__,
+      formatter_class=argparse.RawDescriptionHelpFormatter,
+      usage=USAGE_STRING)
+
+  setattr(argparser, 'man_short_description', __doc__.strip().splitlines()[0])
+
+  setup_argparse(argparser)
+  return argparser
+
+
 USAGE_STRING = """
 cmake-genparsers [-h] [-o OUTFILE_PATH] infilepath [infilepath ...]
 """
@@ -223,12 +235,7 @@ def main():
   """Parse arguments, open files, start work."""
   logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 
-  argparser = argparse.ArgumentParser(
-      description=__doc__,
-      formatter_class=argparse.RawDescriptionHelpFormatter,
-      usage=USAGE_STRING)
-
-  setup_argparse(argparser)
+  argparser = get_argparser()
   args = argparser.parse_args()
   logging.getLogger().setLevel(getattr(logging, args.log_level.upper()))
 

--- a/cmakelang/lint/__main__.py
+++ b/cmakelang/lint/__main__.py
@@ -94,16 +94,23 @@ cmake-lint [-h]
 """
 
 
-def inner_main():
-  """Parse arguments, open files, start work."""
-  logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
-
-  argparser = argparse.ArgumentParser(
+def get_argparser():
+  arg_parser = argparse.ArgumentParser(
+      prog='cmake-lint',
       description=__doc__,
       formatter_class=argparse.RawDescriptionHelpFormatter,
       usage=USAGE_STRING)
 
-  setup_argparse(argparser)
+  setattr(arg_parser, 'man_short_description', __doc__.strip().splitlines()[0])
+
+  setup_argparse(arg_parser)
+  return arg_parser
+
+def inner_main():
+  """Parse arguments, open files, start work."""
+  logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+  argparser = get_argparser()
   try:
     import argcomplete
     argcomplete.autocomplete(argparser)


### PR DESCRIPTION
https://pypi.org/project/argparse-manpage/

* Refactor construction of `argparse.ArgumentParser` into a `get_argparser()` function in each binary.
* Set `prog` property (the default uses `sys.arg[0]` which breaks with `argparse-manpage`, arguably this is an `argparse-manpage` bug).
* Set the `man_short_description` property based on the first line of the description. This is used as a summary in the `NAME` section of the man page.