### PR TITLE
Correct path substitution in VS Code extension

### DIFF
--- a/cmakelang/vscode_extension/src/extension.ts
+++ b/cmakelang/vscode_extension/src/extension.ts
@@ -36,7 +36,7 @@ function getWorkspaceFolder(): string | undefined {
       + `'${fallbackWorkspace.name}' path`);
     workspacePath = fallbackWorkspace;
   }
-  return workspacePath.uri.path;
+  return workspacePath.uri.fsPath;
 }
 
 function varSub(value: string): string {


### PR DESCRIPTION
Use the filesystem path fsPath and not just path when substituting ${workspaceFolder}.

Closes #327