### PR TITLE
Make pip editable install's work (avoid multiple .egg_infos)

### DIFF
--- a/cmakelang/pypi/setup.py
+++ b/cmakelang/pypi/setup.py
@@ -1,7 +1,10 @@
 import io
 from setuptools import setup
+import sys
 
 GITHUB_URL = "https://github.com/cheshirekow/cmakelang"
+
+only_cmakelang = len(sys.argv) != 1
 
 VERSION = None
 with io.open("cmakelang/__init__.py", encoding="utf-8") as infile:
@@ -15,6 +18,7 @@ assert VERSION is not None
 
 with io.open("cmakelang/doc/README.rst", encoding="utf-8") as infile:
   long_description = infile.read()
+
 
 setup(
     name="cmakelang",
@@ -62,96 +66,102 @@ setup(
     install_requires=["six>=1.13.0"]
 )
 
-setup(
-    name="cmake-annotate",
-    packages=[],
-    version=VERSION,
-    description="Can format your listfiles so they don't look like crap",
-    long_description=long_description,
-    author="Josh Bialkowski",
-    author_email="josh.bialkowski@gmail.com",
-    url=GITHUB_URL,
-    download_url="{}/archive/{}.tar.gz".format(GITHUB_URL, VERSION),
-    keywords=["cmake", "annotate"],
-    license="GPLv3",
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
-    ],
-    include_package_data=True,
-    install_requires=[
-        "cmakelang>={}".format(VERSION),
-        "pyyaml>=5.3"]
-)
 
-setup(
-    name="cmake-format",
-    packages=[],
-    version=VERSION,
-    description="Can format your listfiles so they don't look like crap",
-    long_description=long_description,
-    author="Josh Bialkowski",
-    author_email="josh.bialkowski@gmail.com",
-    url=GITHUB_URL,
-    download_url="{}/archive/{}.tar.gz".format(GITHUB_URL, VERSION),
-    keywords=["cmake", "format", "formatter"],
-    license="GPLv3",
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
-    ],
-    include_package_data=True,
-    extras_require={
-        "YAML": ["pyyaml>=5.3"],
-    },
-    install_requires=["cmakelang>={}".format(VERSION)]
-)
+if not only_cmakelang:
+    setup(
+        name="cmake-annotate",
+        packages=[],
+        version=VERSION,
+        description="Can format your listfiles so they don't look like crap",
+        long_description=long_description,
+        author="Josh Bialkowski",
+        author_email="josh.bialkowski@gmail.com",
+        url=GITHUB_URL,
+        download_url="{}/archive/{}.tar.gz".format(GITHUB_URL, VERSION),
+        keywords=["cmake", "annotate"],
+        license="GPLv3",
+        classifiers=[
+            "Development Status :: 3 - Alpha",
+            "Intended Audience :: Developers",
+            "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
+        ],
+        include_package_data=True,
+        install_requires=[
+            "cmakelang>={}".format(VERSION),
+            "pyyaml>=5.3"]
+    )
 
 
-setup(
-    name="cmake-lint",
-    packages=[],
-    version=VERSION,
-    description="Can check your listfiles for common problems",
-    long_description=long_description,
-    author="Josh Bialkowski",
-    author_email="josh.bialkowski@gmail.com",
-    url=GITHUB_URL,
-    download_url="{}/archive/{}.tar.gz".format(GITHUB_URL, VERSION),
-    keywords=["cmake", "lint", "linter"],
-    license="GPLv3",
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
-    ],
-    include_package_data=True,
-    extras_require={
-        "YAML": ["pyyaml>=5.3"],
-    },
-    install_requires=["cmakelang>={}".format(VERSION)]
-)
+if not only_cmakelang:
+    setup(
+        name="cmake-format",
+        packages=[],
+        version=VERSION,
+        description="Can format your listfiles so they don't look like crap",
+        long_description=long_description,
+        author="Josh Bialkowski",
+        author_email="josh.bialkowski@gmail.com",
+        url=GITHUB_URL,
+        download_url="{}/archive/{}.tar.gz".format(GITHUB_URL, VERSION),
+        keywords=["cmake", "format", "formatter"],
+        license="GPLv3",
+        classifiers=[
+            "Development Status :: 3 - Alpha",
+            "Intended Audience :: Developers",
+            "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
+        ],
+        include_package_data=True,
+        extras_require={
+            "YAML": ["pyyaml>=5.3"],
+        },
+        install_requires=["cmakelang>={}".format(VERSION)]
+    )
 
 
-setup(
-    name="cmake-parse",
-    packages=[],
-    version=VERSION,
-    description="Python library for parsing cmake listfiles. ",
-    long_description=long_description,
-    author="Josh Bialkowski",
-    author_email="josh.bialkowski@gmail.com",
-    url=GITHUB_URL,
-    download_url="{}/archive/{}.tar.gz".format(GITHUB_URL, VERSION),
-    keywords=["cmake", "lint", "linter"],
-    license="GPLv3",
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
-    ],
-    include_package_data=True,
-    install_requires=["cmakelang>={}".format(VERSION)]
-)
+if not only_cmakelang:
+    setup(
+        name="cmake-lint",
+        packages=[],
+        version=VERSION,
+        description="Can check your listfiles for common problems",
+        long_description=long_description,
+        author="Josh Bialkowski",
+        author_email="josh.bialkowski@gmail.com",
+        url=GITHUB_URL,
+        download_url="{}/archive/{}.tar.gz".format(GITHUB_URL, VERSION),
+        keywords=["cmake", "lint", "linter"],
+        license="GPLv3",
+        classifiers=[
+            "Development Status :: 3 - Alpha",
+            "Intended Audience :: Developers",
+            "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
+        ],
+        include_package_data=True,
+        extras_require={
+            "YAML": ["pyyaml>=5.3"],
+        },
+        install_requires=["cmakelang>={}".format(VERSION)]
+    )
+
+
+if not only_cmakelang:
+    setup(
+        name="cmake-parse",
+        packages=[],
+        version=VERSION,
+        description="Python library for parsing cmake listfiles. ",
+        long_description=long_description,
+        author="Josh Bialkowski",
+        author_email="josh.bialkowski@gmail.com",
+        url=GITHUB_URL,
+        download_url="{}/archive/{}.tar.gz".format(GITHUB_URL, VERSION),
+        keywords=["cmake", "lint", "linter"],
+        license="GPLv3",
+        classifiers=[
+            "Development Status :: 3 - Alpha",
+            "Intended Audience :: Developers",
+            "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
+        ],
+        include_package_data=True,
+        install_requires=["cmakelang>={}".format(VERSION)]
+    )


### PR DESCRIPTION
pip doesn't support multiple setup() calls in setup.py - it complains about the multiple .egg_infos generated. This workaround skips calling the non-cmakalang setups() if there is an argument provided to setup.py.