### PR TITLE
do not add spaces within hash ruler (#############)

### DIFF
--- a/cmakelang/format/formatter.py
+++ b/cmakelang/format/formatter.py
@@ -99,7 +99,7 @@ def format_comment_lines(node, stack_context, line_width):
 
   items = markup.parse(inlines, config)
   markup_lines = markup.format_items(config, max(10, line_width - 2), items)
-  return [prefix + (" " * len(line[:1])) + line for line in markup_lines]
+  return [prefix + (" " * len(line[:1]) if not line.startswith(prefix) else "") + line for line in markup_lines]
 
 
 def normalize_line_endings(instr):

--- a/cmakelang/format/testdata/test_in.cmake
+++ b/cmakelang/format/testdata/test_in.cmake
@@ -10,6 +10,10 @@ project(cmakelang_test)
 # into a single comment
 # on one line
 
+######################
+# This is some section
+######################
+
 # This comment should remain right before the command call.
 # Furthermore, the command call should be formatted
 # to a single line.

--- a/cmakelang/format/testdata/test_out.cmake
+++ b/cmakelang/format/testdata/test_out.cmake
@@ -5,6 +5,10 @@ project(cmakelang_test)
 
 # This multiline-comment should be reflowed into a single comment on one line
 
+###############################################################################
+# This is some section
+###############################################################################
+
 # This comment should remain right before the command call. Furthermore, the
 # command call should be formatted to a single line.
 add_subdirectories(foo bar baz foo2 bar2 baz2)


### PR DESCRIPTION
Currently there is always a space added after the prefix in comments. This breaks the lines with only `#####` (so called hash ruler).
Therefore a line `#############` becomes to '# ################' which looks ugly.

With this change now a space is only added if the comment does not start with `prefix` itself.