### PR TITLE
Support variable substitution in exePath

### DIFF
--- a/cmakelang/vscode_extension/src/extension.ts
+++ b/cmakelang/vscode_extension/src/extension.ts
@@ -69,7 +69,7 @@ export function activate(context: vscode.ExtensionContext) {
       var fs = require('fs')
       var path = require('path')
       var config = vscode.workspace.getConfiguration('cmakeFormat');
-      var exePath = config.get("exePath");
+      var exePath = varSub(config.get("exePath"));
 
       var args = config.get<string[]>("args", [])
       // NOTE(josh): in case the final user-supplied argument is a


### PR DESCRIPTION
Currently, the "exePath" in settings.json has to be an absolute path. No variable substitution is supported. Hence, settings like this do not work:
```json
{
    "cmakeFormat.exePath": "${workspaceRoot}/tools/cmake_format/cmake-format.exe",
}
```
A function `varSub` is already provided but is currently only used for arguments. I added the substitution to the exePath.
