### PR TITLE
Add FILE_SET and RUNTIME_DEPENDENCIES support

### DIFF
--- a/cmakelang/command_tests/__init__.py
+++ b/cmakelang/command_tests/__init__.py
@@ -533,7 +533,7 @@ class TestInstall(TestBase):
   """
   Test various examples of the install command
   """
-  kExpectNumSidecarTests = 3
+  kExpectNumSidecarTests = 5
 
 
 class TestSetTargetProperties(TestBase):

--- a/cmakelang/command_tests/__init__.py
+++ b/cmakelang/command_tests/__init__.py
@@ -533,7 +533,7 @@ class TestInstall(TestBase):
   """
   Test various examples of the install command
   """
-  kExpectNumSidecarTests = 5
+  kExpectNumSidecarTests = 8
 
 
 class TestSetTargetProperties(TestBase):

--- a/cmakelang/command_tests/__init__.py
+++ b/cmakelang/command_tests/__init__.py
@@ -533,7 +533,7 @@ class TestInstall(TestBase):
   """
   Test various examples of the install command
   """
-  kExpectNumSidecarTests = 8
+  kExpectNumSidecarTests = 9
 
 
 class TestSetTargetProperties(TestBase):

--- a/cmakelang/command_tests/install_tests.cmake
+++ b/cmakelang/command_tests/install_tests.cmake
@@ -92,3 +92,16 @@ install(
   TARGETS target #
   CONFIGURATIONS Debug
   RUNTIME DESTINATION Debug/bin)
+
+# test: install_file_set
+install(TARGETS mylib FILE_SET myheaders DESTINATION include/mylib)
+
+# test: install_file_set_with_component
+install(
+  TARGETS mylib
+  FILE_SET HEADERS
+           DESTINATION include
+           COMPONENT Development
+  FILE_SET mymodules
+           DESTINATION lib/cmake
+           COMPONENT Development)

--- a/cmakelang/command_tests/install_tests.cmake
+++ b/cmakelang/command_tests/install_tests.cmake
@@ -105,3 +105,27 @@ install(
   FILE_SET mymodules
            DESTINATION lib/cmake
            COMPONENT Development)
+
+# test: install_runtime_dependency_set
+install(
+  RUNTIME_DEPENDENCY_SET mydeps
+  LIBRARY DESTINATION lib COMPONENT runtime
+  RUNTIME DESTINATION bin COMPONENT runtime
+  PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-"
+  POST_EXCLUDE_REGEXES ".*system32/.*\\.dll"
+  DIRECTORIES ${CMAKE_INSTALL_PREFIX}/bin)
+
+# test: install_targets_with_runtime_dependency_set
+install(
+  TARGETS myapp
+  RUNTIME_DEPENDENCY_SET mydeps
+  RUNTIME DESTINATION bin COMPONENT runtime)
+
+# test: install_targets_with_runtime_dependencies
+install(
+  TARGETS myapp
+  RUNTIME_DEPENDENCIES
+    PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-"
+    POST_EXCLUDE_REGEXES ".*system32/.*\\.dll"
+    DIRECTORIES ${CMAKE_INSTALL_PREFIX}/bin
+  RUNTIME DESTINATION bin)

--- a/cmakelang/command_tests/install_tests.cmake
+++ b/cmakelang/command_tests/install_tests.cmake
@@ -129,3 +129,9 @@ install(
     POST_EXCLUDE_REGEXES ".*system32/.*\\.dll"
     DIRECTORIES ${CMAKE_INSTALL_PREFIX}/bin
   RUNTIME DESTINATION bin)
+
+# test: install_cxx_modules_bmi
+install(
+  TARGETS mymodule
+  FILE_SET CXX_MODULES DESTINATION lib/cxx/miu
+  CXX_MODULES_BMI DESTINATION lib/cxx/bmi COMPONENT Development)

--- a/cmakelang/command_tests/misc_tests.cmake
+++ b/cmakelang/command_tests/misc_tests.cmake
@@ -898,3 +898,30 @@ use_tabchars = True
 if(TRUE)
 	message("Hello world")
 endif()
+
+# test: target_sources_file_set
+target_sources(
+  mylib
+  PUBLIC
+  FILE_SET HEADERS
+           BASE_DIRS include
+           FILES include/mylib.h include/mylib_config.h)
+
+# test: target_sources_file_set_with_type
+target_sources(
+  mylib
+  PUBLIC
+  FILE_SET mymodules
+           TYPE CXX_MODULES
+           BASE_DIRS src
+           FILES src/mymodule.cppm)
+
+# test: target_sources_mixed
+target_sources(
+  mylib
+  PRIVATE src/impl.cpp
+  PUBLIC
+  FILE_SET HEADERS
+           BASE_DIRS include
+           FILES include/mylib.h
+  INTERFACE some_interface.h)

--- a/cmakelang/command_tests/misc_tests.py
+++ b/cmakelang/command_tests/misc_tests.py
@@ -15,7 +15,7 @@ class TestMiscFormatting(TestBase):
   """
   Ensure that various inputs format the way we want them to
   """
-  kExpectNumSidecarTests = 86
+  kExpectNumSidecarTests = 89
 
   def test_config_hashruler_minlength(self):
 

--- a/cmakelang/parse/additional_nodes.py
+++ b/cmakelang/parse/additional_nodes.py
@@ -162,6 +162,32 @@ class PatternNode(StandardArgTree):
     )
 
 
+class FileSetNode(StandardArgTree):
+  """File sets are children of a `FILE_SET` keyword argument and are used
+     in target_sources and install commands (CMake 3.23+)."""
+
+  @classmethod
+  def parse(cls, ctx, tokens, breakstack):
+    """
+    ::
+
+      FILE_SET <set> [TYPE <type>] [BASE_DIRS <dirs>...] [FILES <files>...]
+
+    :see: https://cmake.org/cmake/help/latest/command/target_sources.html
+    """
+    return super(FileSetNode, cls).parse(
+        ctx, tokens,
+        npargs=1,  # The set name
+        kwargs={
+            "TYPE": PositionalParser(1),
+            "BASE_DIRS": PositionalParser('+'),
+            "FILES": PositionalParser('+'),
+        },
+        flags=[],
+        breakstack=breakstack
+    )
+
+
 class FlagGroupNode(PositionalGroupNode):
   """A positinal group where each argument is a flag."""
 

--- a/cmakelang/parse/funs/install.py
+++ b/cmakelang/parse/funs/install.py
@@ -70,6 +70,7 @@ def parse_install_targets(ctx, tokens, breakstack):
   ::
 
     install(TARGETS targets... [EXPORT <export-name>]
+            [RUNTIME_DEPENDENCIES <arg>...|RUNTIME_DEPENDENCY_SET <set-name>]
             [[ARCHIVE|LIBRARY|RUNTIME|OBJECTS|FRAMEWORK|BUNDLE|
               PRIVATE_HEADER|PUBLIC_HEADER|RESOURCE|FILE_SET <set>]
              [DESTINATION <dir>]
@@ -88,6 +89,8 @@ def parse_install_targets(ctx, tokens, breakstack):
   kwargs = {
       "TARGETS": PositionalParser('+'),
       "EXPORT": PositionalParser(1),
+      "RUNTIME_DEPENDENCY_SET": PositionalParser(1),
+      "RUNTIME_DEPENDENCIES": parse_install_runtime_dependencies_sub,
       "INCLUDES": PositionalParser('+', flags=["DESTINATION"]),
       # Common kwargs
       "DESTINATION": PositionalParser(1),
@@ -311,6 +314,73 @@ def parse_install_export(ctx, tokens, breakstack):
       breakstack=breakstack)
 
 
+def parse_install_runtime_dependencies_sub(ctx, tokens, breakstack):
+  """
+  Parse the inner kwargs of ``RUNTIME_DEPENDENCIES`` within install(TARGETS).
+  These are the filtering options for runtime dependency resolution.
+
+  :see: https://cmake.org/cmake/help/latest/command/install.html#targets
+  """
+  return StandardArgTree.parse(
+      ctx, tokens,
+      npargs='*',
+      kwargs={
+          "PRE_INCLUDE_REGEXES": PositionalParser('+'),
+          "PRE_EXCLUDE_REGEXES": PositionalParser('+'),
+          "POST_INCLUDE_REGEXES": PositionalParser('+'),
+          "POST_EXCLUDE_REGEXES": PositionalParser('+'),
+          "POST_INCLUDE_FILES": PositionalParser('+'),
+          "POST_EXCLUDE_FILES": PositionalParser('+'),
+          "DIRECTORIES": PositionalParser('+'),
+      },
+      flags=[],
+      breakstack=breakstack)
+
+
+def parse_install_runtime_dependency_set(ctx, tokens, breakstack):
+  """
+  ::
+
+    install(RUNTIME_DEPENDENCY_SET <set-name>
+            [[LIBRARY|RUNTIME|FRAMEWORK]
+             [DESTINATION <dir>]
+             [PERMISSIONS permissions...]
+             [CONFIGURATIONS [Debug|Release|...]]
+             [COMPONENT <component>]
+             [NAMELINK_COMPONENT <component>]
+             [OPTIONAL] [EXCLUDE_FROM_ALL]
+            ] [...]
+            [PRE_INCLUDE_REGEXES regex...]
+            [PRE_EXCLUDE_REGEXES regex...]
+            [POST_INCLUDE_REGEXES regex...]
+            [POST_EXCLUDE_REGEXES regex...]
+            [POST_INCLUDE_FILES file...]
+            [POST_EXCLUDE_FILES file...]
+            [DIRECTORIES dir...]
+            )
+
+  :see: https://cmake.org/cmake/help/latest/command/install.html#runtime-dependency-set
+  """
+  return StandardArgTree.parse(
+      ctx, tokens,
+      npargs='*',
+      kwargs={
+          "RUNTIME_DEPENDENCY_SET": PositionalParser(1),
+          "LIBRARY": parse_install_targets_sub,
+          "RUNTIME": parse_install_targets_sub,
+          "FRAMEWORK": parse_install_targets_sub,
+          "PRE_INCLUDE_REGEXES": PositionalParser('+'),
+          "PRE_EXCLUDE_REGEXES": PositionalParser('+'),
+          "POST_INCLUDE_REGEXES": PositionalParser('+'),
+          "POST_EXCLUDE_REGEXES": PositionalParser('+'),
+          "POST_INCLUDE_FILES": PositionalParser('+'),
+          "POST_EXCLUDE_FILES": PositionalParser('+'),
+          "DIRECTORIES": PositionalParser('+'),
+      },
+      flags=[],
+      breakstack=breakstack)
+
+
 def parse_install(ctx, tokens, breakstack):
   """
   The ``install()`` command has multiple different forms, implemented
@@ -323,8 +393,9 @@ def parse_install(ctx, tokens, breakstack):
   * SCRIPT
   * CODE
   * EXPORT
+  * RUNTIME_DEPENDENCY_SET
 
-  :see: https://cmake.org/cmake/help/v3.0/command/install.html
+  :see: https://cmake.org/cmake/help/latest/command/install.html
   """
 
   descriminator_token = get_first_semantic_token(tokens)
@@ -341,7 +412,8 @@ def parse_install(ctx, tokens, breakstack):
       "DIRECTORY": parse_install_directory,
       "SCRIPT": parse_install_script,
       "CODE": parse_install_script,
-      "EXPORT": parse_install_export
+      "EXPORT": parse_install_export,
+      "RUNTIME_DEPENDENCY_SET": parse_install_runtime_dependency_set,
   }
   if descriminator not in parsemap:
     logger.warning("Invalid install form \"%s\" at %s", descriminator,

--- a/cmakelang/parse/funs/install.py
+++ b/cmakelang/parse/funs/install.py
@@ -139,7 +139,7 @@ def parse_install_targets(ctx, tokens, breakstack):
     word = get_normalized_kwarg(tokens[0])
     if word in designated_kwargs:
       subtree = KeywordGroupNode.parse(
-          ctx, tokens, word, parse_install_targets, subtree_breakstack)
+          ctx, tokens, word, parse_install_targets_sub, subtree_breakstack)
     elif word in kwargs:
       subtree = KeywordGroupNode.parse(
           ctx, tokens, word, kwargs[word], kwarg_breakstack)

--- a/cmakelang/parse/funs/install.py
+++ b/cmakelang/parse/funs/install.py
@@ -5,7 +5,7 @@ from cmakelang.parse.common import KwargBreaker
 from cmakelang.parse.simple_nodes import CommentNode
 from cmakelang.parse.argument_nodes import (
     KeywordGroupNode, PositionalGroupNode, PositionalParser, StandardArgTree)
-from cmakelang.parse.additional_nodes import PatternNode
+from cmakelang.parse.additional_nodes import FileSetNode, PatternNode
 from cmakelang.parse.util import (
     WHITESPACE_TOKENS,
     get_first_semantic_token,
@@ -40,13 +40,38 @@ def parse_install_targets_sub(ctx, tokens, breakstack):
       breakstack=breakstack)
 
 
+def parse_install_file_set_sub(ctx, tokens, breakstack):
+  """
+    Parse the inner kwargs of an ``install(TARGETS ... FILE_SET)`` command.
+    FILE_SET requires a set name followed by optional destination kwargs.
+  :see: https://cmake.org/cmake/help/latest/command/install.html#targets
+  """
+  return StandardArgTree.parse(
+      ctx, tokens,
+      npargs=1,  # The file set name
+      kwargs={
+          "DESTINATION": PositionalParser(1),
+          "PERMISSIONS": PositionalParser('+'),
+          "CONFIGURATIONS": PositionalParser('+'),
+          "COMPONENT": PositionalParser(1),
+          "NAMELINK_COMPONENT": PositionalParser(1),
+      },
+      flags=[
+          "OPTIONAL",
+          "EXCLUDE_FROM_ALL",
+          "NAMELINK_ONLY",
+          "NAMELINK_SKIP"
+      ],
+      breakstack=breakstack)
+
+
 def parse_install_targets(ctx, tokens, breakstack):
   """
   ::
 
     install(TARGETS targets... [EXPORT <export-name>]
             [[ARCHIVE|LIBRARY|RUNTIME|OBJECTS|FRAMEWORK|BUNDLE|
-              PRIVATE_HEADER|PUBLIC_HEADER|RESOURCE]
+              PRIVATE_HEADER|PUBLIC_HEADER|RESOURCE|FILE_SET <set>]
              [DESTINATION <dir>]
              [PERMISSIONS permissions...]
              [CONFIGURATIONS [Debug|Release|...]]
@@ -58,7 +83,7 @@ def parse_install_targets(ctx, tokens, breakstack):
             [INCLUDES DESTINATION [<dir> ...]]
             )
 
-  :see: https://cmake.org/cmake/help/v3.14/command/install.html#targets
+  :see: https://cmake.org/cmake/help/latest/command/install.html#targets
   """
   kwargs = {
       "TARGETS": PositionalParser('+'),
@@ -79,7 +104,8 @@ def parse_install_targets(ctx, tokens, breakstack):
   )
   designated_kwargs = (
       "ARCHIVE", "LIBRARY", "RUNTIME", "OBJECTS", "FRAMEWORK",
-      "BUNDLE", "PRIVATE_HEADER", "PUBLIC_HEADER", "RESOURCE"
+      "BUNDLE", "PRIVATE_HEADER", "PUBLIC_HEADER", "RESOURCE",
+      "FILE_SET"
   )
 
   # NOTE(josh): from here on, code is essentially StandardArgTree.parse(),
@@ -138,8 +164,13 @@ def parse_install_targets(ctx, tokens, breakstack):
     # just make sure we check flags first.
     word = get_normalized_kwarg(tokens[0])
     if word in designated_kwargs:
-      subtree = KeywordGroupNode.parse(
-          ctx, tokens, word, parse_install_targets_sub, subtree_breakstack)
+      # FILE_SET requires a set name argument, so use a different subparser
+      if word == "FILE_SET":
+        subtree = KeywordGroupNode.parse(
+            ctx, tokens, word, parse_install_file_set_sub, subtree_breakstack)
+      else:
+        subtree = KeywordGroupNode.parse(
+            ctx, tokens, word, parse_install_targets_sub, subtree_breakstack)
     elif word in kwargs:
       subtree = KeywordGroupNode.parse(
           ctx, tokens, word, kwargs[word], kwarg_breakstack)

--- a/cmakelang/parse/funs/install.py
+++ b/cmakelang/parse/funs/install.py
@@ -72,7 +72,8 @@ def parse_install_targets(ctx, tokens, breakstack):
     install(TARGETS targets... [EXPORT <export-name>]
             [RUNTIME_DEPENDENCIES <arg>...|RUNTIME_DEPENDENCY_SET <set-name>]
             [[ARCHIVE|LIBRARY|RUNTIME|OBJECTS|FRAMEWORK|BUNDLE|
-              PRIVATE_HEADER|PUBLIC_HEADER|RESOURCE|FILE_SET <set>]
+              PRIVATE_HEADER|PUBLIC_HEADER|RESOURCE|
+              FILE_SET <set>|CXX_MODULES_BMI]
              [DESTINATION <dir>]
              [PERMISSIONS permissions...]
              [CONFIGURATIONS [Debug|Release|...]]
@@ -108,7 +109,7 @@ def parse_install_targets(ctx, tokens, breakstack):
   designated_kwargs = (
       "ARCHIVE", "LIBRARY", "RUNTIME", "OBJECTS", "FRAMEWORK",
       "BUNDLE", "PRIVATE_HEADER", "PUBLIC_HEADER", "RESOURCE",
-      "FILE_SET"
+      "FILE_SET", "CXX_MODULES_BMI"
   )
 
   # NOTE(josh): from here on, code is essentially StandardArgTree.parse(),

--- a/cmakelang/parse/funs/random.py
+++ b/cmakelang/parse/funs/random.py
@@ -2,6 +2,7 @@ from cmakelang.parse.argument_nodes import (
     PositionalParser,
     StandardArgTree,
 )
+from cmakelang.parse.additional_nodes import FileSetNode
 from cmakelang.parse.util import (
     iter_semantic_tokens,
 )
@@ -357,7 +358,10 @@ def parse_target_sources(ctx, tokens, breakstack):
 
     target_sources(<target>
       <INTERFACE|PUBLIC|PRIVATE> [items1...]
-      [<INTERFACE|PUBLIC|PRIVATE> [items2...] ...])
+      [<INTERFACE|PUBLIC|PRIVATE> [items2...] ...]
+      [<INTERFACE|PUBLIC|PRIVATE>
+       [FILE_SET <set> [TYPE <type>] [BASE_DIRS <dirs>...] [FILES <files>...]]
+       ...])
 
   :see: https://cmake.org/cmake/help/latest/command/target_sources.html
   """
@@ -365,6 +369,7 @@ def parse_target_sources(ctx, tokens, breakstack):
       "INTERFACE": PositionalParser("+"),
       "PUBLIC": PositionalParser("+"),
       "PRIVATE": PositionalParser("+"),
+      "FILE_SET": FileSetNode.parse,
   }
   return StandardArgTree.parse(ctx, tokens, 1, kwargs, [], breakstack)
 


### PR DESCRIPTION
## Summary
- Fix `parse_install_targets` to use `parse_install_targets_sub` (was dead code)
- Add FILE_SET formatting support for `target_sources()` and `install(TARGETS)` (CMake 3.23+)
- Add RUNTIME_DEPENDENCIES support:
  - `install(RUNTIME_DEPENDENCY_SET)` as standalone form
  - `RUNTIME_DEPENDENCIES` and `RUNTIME_DEPENDENCY_SET` in `install(TARGETS)` (CMake 3.21+)

## Test plan
- [x] Added test cases for all new features
- [x] All existing tests pass
- [x] Formatted a real project (229 CMakeLists.txt files) without errors